### PR TITLE
OSIDB-3712: Create container image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   type-check:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 /playwright/.auth/
 .vscode
 .env
+*.keytab

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,12 @@
+.gitignore
+*.md
+.git
+.vscode
+.github
+.husky
+test-results
+playwright-report
+user.json
+Dockerfile
+node_modules
+.env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM registry.redhat.io/ubi9/ubi:9.5 as base
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV KRB5CCNAME=/tmp/cache
+
+COPY docker/krb5.conf /etc/krb5.conf
+COPY docker/install-certs.sh /install-certs.sh
+COPY docker/auth.sh /auth.sh
+
+RUN ./install-certs.sh $RH_CERT_URL \
+    && yum update -y \
+    && yum install -y wget git krb5-workstation \
+    # Playwright dependencies
+    libxcb libXdamage libXcursor libXext libXcomposite libXrandr \
+    libXi pango cairo cairo-gobject libXrender gtk3 atk gdk-pixbuf2 \
+    # NodeJS
+    && yum module install -y nodejs:20/common \
+    && yum clean all \
+    && npm install -g yarn \
+    && mkdir -p /krb5 \
+    && chmod 755 /krb5 \
+    && mkdir -p /var/lib/sss/pubconf/krb5.include.d \
+    && chmod 755 /etc/krb5.conf.d \
+    && chown -R 1001:0 /etc/krb5.conf.d \
+    && chown 1001:0 /etc/krb5.conf \
+    && chown -R 1001:0 /krb5 
+
+FROM base as build
+
+WORKDIR /app
+ENV PLAYWRIGHT_BROWSERS_PATH=0
+
+COPY --chown=1001 package.json /app/package.json
+COPY --chown=1001 yarn.lock /app/yarn.lock
+COPY --chown=1001 playwright.config.ts /app/playwright.config.ts
+COPY --chown=1001 tsconfig.json /app/tsconfig.json
+COPY --chown=1001 docker/krb5.conf.d /etc/krb5.conf.d
+COPY --chown=1001 docker/krb5.keytab /krb5/krb5.keytab
+
+RUN yarn install --frozen-lockfile \
+    && yarn playwright install chromium firefox
+
+COPY --chown=1001 . /app
+
+USER 1001
+
+CMD ["/bin/sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,62 @@
+# OSIM UI + Kerberos Tests Container 
+
+This is the container that is used to run the tests on the CI/CD pipeline. It is based on redhat's ubi9 image and has the necessary dependencies to run the tests.
+
+## Building the container
+Before building the container, you need to prepare some files.
+
+1. Create a `krb5.keytab` file in the `docker` directory. This file is used to authenticate with kerberos.
+```bash
+$ ktutil
+ktutil:  addent -password -p <principal> -k 1 -e aes256-cts-hmac-sha1-96 -f
+ktutil:  wkt krb5.keytab
+ktutil:  quit
+```
+2. Create a `crypto-policies` file in the `krb5.conf.d` directory. You should have this file in `/etc/krb5.conf.d/` or `/usr/bin/krb5-conf/` on your machine.
+
+
+3. Provide the correct realm configuration in a file inside the `krb5.conf.d` directory. You should have this file in `/etc/krb5.conf` on your machine.
+
+
+That should look like this:
+```bash
+|-- docker
+|   |-- krb5.conf.d
+|   |   |-- crypto-policies
+|   |   |-- realm # name of the file is not important
+|   |-- krb5.keytab
+|   |-- krb5.conf
+|   |-- Dockerfile
+```
+
+After preparing the files, you can build the container using the following command:
+
+> [!IMPORTANT]
+> Make sure to run the command from the root of the project.
+> (outside of the docker folder)
+
+```bash
+podman build -t osim-ui-tests -f docker/Dockerfile --ignorefile docker/.dockerignore .
+# to install RH certificates add --env RH_CERT_URL=<url> to the command
+```
+
+## Running the container
+Make sure to provide the required [environment variables](/README.md#required-environment-variables) when running the container:
+
+```bash
+podman run --rm -it --env-file .env osim-ui-tests
+```
+
+## Running the tests
+
+You need to authenticate with kerberos before running the tests. You can do this by running the script **inside the container**:
+
+```bash
+sh /auth.sh
+```
+
+After authenticating, you can run the tests using the following command:
+
+```bash
+yarn test
+```

--- a/docker/auth.sh
+++ b/docker/auth.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+principal="$( klist -kt /krb5/krb5.keytab | grep -Eo -m1 '\w+@[A-Z.]+' )"
+
+kinit -k -t /krb5/krb5.keytab $principal
+klist -c /tmp/cache

--- a/docker/install-certs.sh
+++ b/docker/install-certs.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [[ -z "${1}" ]]; then
+    echo -e "\e[1;33mWARNING: RH_CERT_URL environment variable not set, internal RH resources won't be accessible\e[0m"
+else
+    curl "${1}/certs/Current-IT-Root-CAs.pem" -o /etc/pki/ca-trust/source/anchors/Current-IT-Root-CAs.pem
+    mkdir -p /etc/ipa
+    curl "${1}/chains/ipa-ca-chain-2015.crt" -o /etc/ipa/ipa.crt
+    update-ca-trust
+fi

--- a/docker/krb5.conf
+++ b/docker/krb5.conf
@@ -1,0 +1,31 @@
+# To opt out of the system crypto-policies configuration of krb5, remove the
+# symlink at /etc/krb5.conf.d/crypto-policies which will not be recreated.
+includedir /etc/krb5.conf.d/
+
+[logging]
+    default = FILE:/var/log/krb5libs.log
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+    dns_lookup_realm = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+    pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
+    spake_preauth_groups = edwards25519
+    dns_canonicalize_hostname = fallback
+    qualify_shortname = ""
+#    default_realm = EXAMPLE.COM
+    default_ccache_name = KEYRING:persistent:%{uid}
+
+[realms]
+# EXAMPLE.COM = {
+#     kdc = kerberos.example.com
+#     admin_server = kerberos.example.com
+# }
+
+[domain_realm]
+# .example.com = EXAMPLE.COM
+# example.com = EXAMPLE.COM

--- a/docker/krb5.conf.d/.gitignore
+++ b/docker/krb5.conf.d/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "private": true,
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",
-    "@playwright/browser-chromium": "^1.48.2",
-    "@playwright/browser-firefox": "^1.48.2",
     "@playwright/test": "^1.48.2",
     "@stylistic/eslint-plugin": "^2.10.1",
     "@types/eslint__js": "^8.42.3",
@@ -26,9 +24,9 @@
     "undici": "^6.21.0"
   },
   "scripts": {
-    "test": "playwright test --reporter=list",
-    "test:chrome": "playwright test --reporter=list --project=chrome",
-    "test:firefox": "playwright test --reporter=list --project=firefox",
+    "test": "playwright test",
+    "test:chromium": "playwright test --project=chromium",
+    "test:firefox": "playwright test --project=firefox",
     "dev": "playwright test --ui",
     "lint": "eslint . ",
     "lint:fix": "eslint . --fix",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? [['dot'], ['junit', {outputFile: 'results.xml'}]] : 'list',
   use: {
     storageState: 'playwright/.auth/user.json',
     ignoreHTTPSErrors: true,

--- a/playwright/helpers.ts
+++ b/playwright/helpers.ts
@@ -1,9 +1,10 @@
 import { Agent, setGlobalDispatcher } from 'undici';
 import { GSS_MECH_OID_KRB5, initializeClient } from 'kerberos';
 import { type BrowserContextOptions } from '@playwright/test';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import dayjs_base from 'dayjs';
 import utc_plugin from 'dayjs/plugin/utc';
+import { existsSync } from 'fs';
 
 dayjs_base.extend(utc_plugin);
 
@@ -19,6 +20,8 @@ interface JSONResponse {
   access: string;
   refresh: string;
 }
+
+const storagePath = 'playwright/.auth/';
 
 export async function authenticate(): Promise<{ refresh: string; access: string }> {
   const client = await initializeClient(`HTTP@${process.env.OSIDB_URL}`, {
@@ -42,12 +45,15 @@ type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 type Storage = Exclude<BrowserContextOptions['storageState'], undefined | string>;
 
 export async function loadStorage(): Promise<Storage> {
-  const storage = JSON.parse(await readFile('playwright/.auth/user.json', 'utf8')) as Storage;
+  const storage = JSON.parse(await readFile(`${storagePath}/user.json`, 'utf8')) as Storage;
   return storage;
 }
 
 export async function saveStorage(storage: Optional<Storage, 'cookies'>): Promise<void> {
-  await writeFile('playwright/.auth/user.json', JSON.stringify(storage, null, 2));
+  if (!existsSync(storagePath)) {
+    await mkdir(storagePath, { recursive: true });
+  }
+  await writeFile(`${storagePath}/user.json`, JSON.stringify(storage, null, 2));
 }
 
 export const { utc: dayjs } = dayjs_base;

--- a/tests/flaw.spec.ts
+++ b/tests/flaw.spec.ts
@@ -55,8 +55,8 @@ test.describe('flaw creation', () => {
       test.slow();
       await flawCreatePage.createFlaw({ type, full: true });
 
-      await expect.soft(page.getByText('Flaw created')).toBeVisible();
-      await expect(page).toHaveURL(/flaws\/(?!new)\w+/);
+      await expect.soft(page.getByText('Flaw created')).toBeVisible({ timeout: 60_000 });
+      await expect(page).toHaveURL(/flaws\/(?!new)\w+/, { timeout: 60_000 });
     });
   });
   // TODO: Add tests for specific fields and special cases.
@@ -88,7 +88,7 @@ test.describe('flaw edition', () => {
     await flawEditPage.submitButton.click();
 
     await expect(page.getByText('Flaw saved')).toBeVisible();
-    await expect(page.getByText(newTitle)).toBeVisible();
+    await expect(page.getByText(newTitle, { exact: true })).toBeVisible();
   });
 
   test.describe('affects', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,20 +114,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/browser-chromium@^1.48.2":
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/@playwright/browser-chromium/-/browser-chromium-1.48.2.tgz#7693eb46a4a5d5c7b1a5bf89b56b08b62c9963ab"
-  integrity sha512-TvYJ5PFaDPYNlKpvPSftBbPTnu75VdRKjoMjmkd7/P79rFIBD+v6K4wU8XR6PlAqqFdPcfLL5XXZnRwTRixbDQ==
-  dependencies:
-    playwright-core "1.48.2"
-
-"@playwright/browser-firefox@^1.48.2":
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/@playwright/browser-firefox/-/browser-firefox-1.48.2.tgz#ebbb4ca4ee6f5200218a856c211184dfc0a164a3"
-  integrity sha512-Cf0ZvgOCmmyqNbFLC2KQyV6RdTxfmuUzASnVhA7unT9xV3zK0TGv5xJZH4ACRMMdYeZ/pSK3SWyewmjMEvSo3g==
-  dependencies:
-    playwright-core "1.48.2"
-
 "@playwright/test@^1.48.2":
   version "1.48.2"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.2.tgz#87dd40633f980872283404c8142a65744d3f13d6"


### PR DESCRIPTION
This pull request introduces several changes to improve the Docker-based CI/CD pipeline for running tests, including updates to the Docker configuration, scripts, and test settings.

### Docker Configuration and Scripts:
* Added a `.dockerignore` file to exclude unnecessary files from the Docker build context.
* Created a `Dockerfile` to set up the environment for running tests, including installing dependencies and configuring Kerberos authentication.
* Added `auth.sh` script for Kerberos authentication within the container.
* Added `install-certs.sh` script to install Red Hat certificates if the `RH_CERT_URL` environment variable is set.
* Added `krb5.conf` configuration file for Kerberos.
* Added `.gitignore` to the `krb5.conf.d` directory.

### Documentation:
* Created a `README.md` file in the `docker` directory to provide instructions on building and running the Docker container, as well as running tests within the container.

### Test Configuration:
* Updated `package.json` to simplify test scripts and remove unnecessary dependencies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-L10) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29-R29)
* Modified `playwright.config.ts` to use different reporters based on the CI environment.
* Adjusted test timeouts and expectations in `tests/flaw.spec.ts` to improve reliability. [[1]](diffhunk://#diff-b87dce11d46f759b518e1202af43ff71ac6e7e49eeab60a98926681a160e4202L58-R59) [[2]](diffhunk://#diff-b87dce11d46f759b518e1202af43ff71ac6e7e49eeab60a98926681a160e4202L91-R91)

Closes OSIDB-3712