### PR TITLE
fix jira related tests

### DIFF
--- a/playwright/helpers.ts
+++ b/playwright/helpers.ts
@@ -56,4 +56,29 @@ export async function saveStorage(storage: Optional<Storage, 'cookies'>): Promis
   await writeFile(`${storagePath}/user.json`, JSON.stringify(storage, null, 2));
 }
 
+export async function getFlawFromAPI<T extends string>(uuid: string, fields?: T[]): Promise<Record<T, unknown>> {
+  const { access } = await authenticate();
+
+  let url = `https://${process.env.OSIDB_URL}/osidb/api/v1/flaws/${uuid}`;
+  if (fields) {
+    url += '?' + new URLSearchParams({ include_fields: fields.join(',') }).toString();
+  }
+
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: 'Bearer ' + access,
+    },
+    method: 'GET',
+  });
+
+  return (await resp.json() as Record<T, unknown>);
+}
+
+/**
+ * Sleep is discouraged in tests, don't use for UI interactions.
+ * https://playwright.dev/docs/api/class-page#page-wait-for-timeout
+ */
+export async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 export const { utc: dayjs } = dayjs_base;

--- a/tests/flaw.spec.ts
+++ b/tests/flaw.spec.ts
@@ -72,12 +72,22 @@ test.describe('flaw edition', () => {
     await page.goto(`/flaws/${flawId}`);
   });
 
-  (['public', 'private', 'internal'] as const).forEach((type: CommentType) => {
+  (['public', 'private'] as const).forEach((type: CommentType) => {
     test(`can add a ${type} comment`, async ({ page, flawEditPage }) => {
       await flawEditPage.addComment(type);
 
       await expect(page.getByText(new RegExp(`${type} comment saved`, 'i'))).toBeVisible();
     });
+  });
+
+  test(`can add an internal comment`, async ({ page, flawEditPage }, testInfo) => {
+    // Extend the timeout to account for the time it may take for the Jira task to be created.
+    test.setTimeout(testInfo.timeout + 55_000);
+    await flawEditPage.waitForJiraTask(flawId);
+
+    await flawEditPage.addComment('internal');
+
+    await expect(page.getByText(new RegExp(`internal comment saved`, 'i'))).toBeVisible();
   });
 
   test('can change the title', async ({ page, flawEditPage }) => {


### PR DESCRIPTION
Jira task creation is asynchronous, there are times when is not yet created when loading a recently created flaw.

This pull request adds a helper to wait for the jira task to be created and fixes the `internal comment` test using this new helper