### PR TITLE
global jira link test

### DIFF
--- a/pages/flawCreate.ts
+++ b/pages/flawCreate.ts
@@ -124,7 +124,7 @@ export class FlawCreatePage {
       components: ['e2e', flawId],
       title: 'Test flaw ' + flawId,
       classification: {
-        workflow: '',
+        workflow: 'DEFAULT',
         state: 'NEW',
       },
       comment_zero: faker.hacker.phrase(),

--- a/pages/flawEdit.ts
+++ b/pages/flawEdit.ts
@@ -7,6 +7,7 @@ export type CommentType = 'public' | 'private' | 'internal';
 
 export class FlawEditPage extends FlawCreatePage {
   readonly createJiraTaskButton: Locator;
+  readonly jiraLink: Locator;
 
   readonly publicCommentButton: Locator;
   readonly publicCommentTab: Locator;
@@ -35,6 +36,7 @@ export class FlawEditPage extends FlawCreatePage {
     super(page);
 
     this.createJiraTaskButton = this.page.getByRole('button', { name: 'Create Jira Task' });
+    this.jiraLink = this.page.getByRole('link', { name: ' Open in Jira' });
 
     this.publicCommentTab = this.page.getByRole('button', { name: 'Public Comments', exact: true });
     this.publicCommentButton = this.page.getByRole('button', { name: 'Add Public Comment' });

--- a/tests/flaw.spec.ts
+++ b/tests/flaw.spec.ts
@@ -90,6 +90,19 @@ test.describe('flaw edition', () => {
     await expect(page.getByText(new RegExp(`internal comment saved`, 'i'))).toBeVisible();
   });
 
+  test('jira link opens task in new page', async ({ flawEditPage, context }) => {
+    const jiraLink = flawEditPage.jiraLink;
+    await expect(jiraLink).toHaveAttribute('href', /issue/);
+
+    const [newPage] = await Promise.all([
+      context.waitForEvent('page'),
+      jiraLink.click(),
+    ]);
+
+    expect(newPage).toBeTruthy();
+    await newPage.close();
+  });
+
   test('can change the title', async ({ page, flawEditPage }) => {
     const title = await flawEditPage.titleBox.locator('span', { hasNotText: 'Title' }).innerText();
     const newTitle = title + ' edited';


### PR DESCRIPTION
Adds a test dor the global jira link in the flaw edit view and the required variables for the flaw creation.

Depends on https://github.com/RedHatProductSecurity/osim-ui-tests/pull/2