### PR TITLE
🐛 Fix outdated tests and configs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,7 @@ export default tseslint.config(
     ignores: [
     'eslint.config.mjs',
     'playwright.config.ts',
-    'tests-results/**/*',
+    'test-results/**/*',
     'playwright-report/**/*'
   ]
 }

--- a/pages/flawCreate.ts
+++ b/pages/flawCreate.ts
@@ -28,8 +28,8 @@ export class FlawCreatePage {
   constructor(public readonly page: Page) {
     this.id = faker.string.alphanumeric({ length: 5, casing: 'upper' });
 
-    this.titleBox = page.locator('label').filter({ hasText: 'Title' });
-    this.componentsBox = page.locator('label').filter({ hasText: 'Components' });
+    this.titleBox = page.locator('.osim-input').filter({ hasText: 'Title' });
+    this.componentsBox = page.locator('label').filter({ hasText: 'Source Component' });
     this.impactBox = page.locator('label').filter({ hasText: 'Impact' });
     this.sourceBox = page.locator('label').filter({ hasText: 'CVE Source' });
     this.comment0Box = page.locator('label').filter({ hasText: 'Comment#0' });
@@ -43,7 +43,7 @@ export class FlawCreatePage {
     this.selfAssingBtn = page.getByRole('button', { name: 'Self Assign' });
     this.descriptionBox = page.locator('label').filter({ hasText: 'Description' });
     this.reviewStatusBox = page.locator('label').filter({ hasText: 'Description' });
-    this.cvssCalculatorInput = page.locator('label').filter({ hasText: 'RH CVSS' });
+    this.cvssCalculatorInput = page.locator('label[role="red-hat-cvss"]');
     this.cvssCalculator = page.locator('.cvss-calculator');
 
     this.submitButton = page.getByRole('button', { name: 'Create New Flaw' });

--- a/tests/acknowledgements.spec.ts
+++ b/tests/acknowledgements.spec.ts
@@ -19,9 +19,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
   });
 
   test('can edit an existing acknowledgement', async ({ page }) => {
@@ -31,9 +31,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
     await expect(page.getByText('Jane Smith from Original Company')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Edit Acknowledgment/i }).first().click();
@@ -44,9 +44,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment updated.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
   });
 
   test('can cancel adding a new acknowledgement', async ({ page }) => {
@@ -64,9 +64,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
     await expect(page.getByText('Delete Me from Temporary Corp')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Delete Acknowledgment/i }).first().click();
@@ -74,8 +74,8 @@ test.describe('flaw acknowledgements', () => {
     await expect(page.getByText('Are you sure you want to delete this acknowledgment?')).toBeVisible();
     await page.getByRole('button', { name: 'Confirm' }).click();
 
-    // Uncomment line below to work around OSIM bug with delete reactivity
-    // await page.reload();
+    // Work around OSIM bug with delete reactivity
+    await page.reload();
 
     await expect(page.getByText('Delete Me from Temporary Corp')).not.toBeVisible();
   });
@@ -87,9 +87,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
     await expect(page.getByText('Keep This Person from Permanent Company')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Delete Acknowledgment/i }).first().click();
@@ -145,9 +145,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
 
     const acknowledgementContainer = page.locator('text=UUID Test Person from UUID Test Corp').locator('..');
     await expect(acknowledgementContainer).toBeVisible();
@@ -165,9 +165,9 @@ test.describe('flaw acknowledgements', () => {
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
     await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where acknowledgments remain in edit mode
-    // await page.reload();
-    // await page.getByText(/Acknowledgments: \d+/).click();
+    // Work around OSIM bug where acknowledgments remain in edit mode
+    await page.reload();
+    await page.getByText(/Acknowledgments: \d+/).click();
     await expect(page.getByText(`${testData.name} from ${testData.affiliation}`)).toBeVisible();
   });
 });

--- a/tests/references.spec.ts
+++ b/tests/references.spec.ts
@@ -29,9 +29,9 @@ test.describe('flaw references', () => {
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
     await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where references remain in edit mode
-    // await page.reload();
-    // await page.getByText(/References: \d+/).click();
+    // Work around OSIM bug where references remain in edit mode
+    await page.reload();
+    await page.getByText(/References: \d+/).click();
     await expect(page.getByText('https://original.com/advisory')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Edit Reference/i }).first().click();
@@ -62,9 +62,9 @@ test.describe('flaw references', () => {
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
     await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where references remain in edit mode
-    // await page.reload();
-    // await page.getByText(/References: \d+/).click();
+    // Work around OSIM bug where references remain in edit mode
+    await page.reload();
+    await page.getByText(/References: \d+/).click();
     await expect(page.getByText('https://todelete.com/advisory')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Delete Reference/i }).first().click();
@@ -72,8 +72,8 @@ test.describe('flaw references', () => {
     await expect(page.getByText('Are you sure you want to delete this reference?')).toBeVisible();
     await page.getByRole('button', { name: 'Confirm' }).click();
 
-    // Uncomment line below to work around OSIM bug with delete reactivity
-    // await page.reload();
+    // Work around OSIM bug with delete reactivity
+    await page.reload();
 
     await expect(page.getByText('https://todelete.com/advisory')).not.toBeVisible();
     await expect(page.getByText('Reference to be deleted')).not.toBeVisible();
@@ -87,9 +87,9 @@ test.describe('flaw references', () => {
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
     await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where references remain in edit mode
-    // await page.reload();
-    // await page.getByText(/References: \d+/).click();
+    // Work around OSIM bug where references remain in edit mode
+    await page.reload();
+    await page.getByText(/References: \d+/).click();
     await expect(page.getByText('https://keepthis.com/advisory')).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /Delete Reference/i }).first().click();
@@ -115,9 +115,9 @@ test.describe('flaw references', () => {
 
     await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
 
-    // Uncomment lines below to work around OSIM bug where references remain in edit mode
-    // await page.reload();
-    // await page.getByText(/References: \d+/).click();
+    // Work around OSIM bug where references remain in edit mode
+    await page.reload();
+    await page.getByText(/References: \d+/).click();
 
     const [newPage] = await Promise.all([
       context.waitForEvent('page'),
@@ -143,9 +143,9 @@ test.describe('flaw references', () => {
       await page.getByRole('button', { name: 'Save Changes to References' }).click();
       await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
 
-      // Uncomment lines below to work around OSIM bug where references remain in edit mode
-      // await page.reload();
-      // await page.getByText(/References: \d+/).click();
+      // Work around OSIM bug where references remain in edit mode
+      await page.reload();
+      await page.getByText(/References: \d+/).click();
       await expect(page.locator('.badge.rounded-pill').getByText(label)).toBeVisible();
     }
   });


### PR DESCRIPTION
Updates required for tests to work based in last OSIM changes:

- Add `.first()` to toast assertions in `acknowledgements.spec.ts`, `references.spec.ts`, `flaw.spec.ts`
- Change affects creation toast to match new format
- Uncomment `page.reload()` after deleting references/acknowledgements
- Use `.osim-editable-text-value` for title text extraction
- Increase Jira task polling timeout (10 → 15 attempts)