### PR TITLE
✨ Add optional flaw fields coverage

### DIFF
--- a/pages/flawCreate.ts
+++ b/pages/flawCreate.ts
@@ -53,6 +53,8 @@ export class FlawCreatePage {
     // Go to index first to let the app fully initialize
     await this.page.goto('/');
     await this.page.waitForSelector('text=Loaded', { timeout: 30000 });
+    // Wait for API keys to be loaded from backend (async operation)
+    await this.page.waitForTimeout(2000);
 
     // Navigate via UI click instead of direct URL to avoid guard timing issues
     await this.page.getByRole('link', { name: 'Create Flaw' }).click();
@@ -140,7 +142,7 @@ export class FlawCreatePage {
     await this.submitButton.click();
   }
 
-  static async createFlawWithAPI(options: { embargoed?: boolean } = {}): Promise<string> {
+  static async createFlawWithAPI(options: { embargoed?: boolean; major_incident_state?: string } = {}): Promise<string> {
     const { access } = await authenticate();
     const { embargoed = false } = options;
 

--- a/pages/flawCreate.ts
+++ b/pages/flawCreate.ts
@@ -142,9 +142,9 @@ export class FlawCreatePage {
     await this.submitButton.click();
   }
 
-  static async createFlawWithAPI(options: { embargoed?: boolean; major_incident_state?: string } = {}): Promise<string> {
+  static async createFlawWithAPI(options: { embargoed?: boolean; major_incident_state?: string; withOwner?: boolean } = {}): Promise<string> {
     const { access } = await authenticate();
-    const { embargoed = false, major_incident_state } = options;
+    const { embargoed = false, major_incident_state, withOwner = true } = options;
 
     const flawId = faker.string.alphanumeric({ length: 5, casing: 'upper' });
     const flaw: Record<string, unknown> = {
@@ -159,8 +159,8 @@ export class FlawCreatePage {
       source: 'REDHAT',
       embargoed,
       reported_dt: dayjs().utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'),
-      // Set owner so "My Issues" filter works in CI
-      owner: process.env.JIRA_EMAIL || '',
+      // Set owner so "My Issues" filter works in CI (unless explicitly disabled)
+      owner: withOwner ? (process.env.JIRA_EMAIL || '') : '',
     };
 
     // Only set unembargo_dt for public flaws

--- a/pages/flawCreate.ts
+++ b/pages/flawCreate.ts
@@ -144,7 +144,7 @@ export class FlawCreatePage {
 
   static async createFlawWithAPI(options: { embargoed?: boolean; major_incident_state?: string } = {}): Promise<string> {
     const { access } = await authenticate();
-    const { embargoed = false } = options;
+    const { embargoed = false, major_incident_state } = options;
 
     const flawId = faker.string.alphanumeric({ length: 5, casing: 'upper' });
     const flaw: Record<string, unknown> = {
@@ -166,6 +166,11 @@ export class FlawCreatePage {
     // Only set unembargo_dt for public flaws
     if (!embargoed) {
       flaw.unembargo_dt = dayjs().utc().subtract(5, 'minutes').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+    }
+
+    // Set major_incident_state if provided (required for incident state tests)
+    if (major_incident_state) {
+      flaw.major_incident_state = major_incident_state;
     }
 
     const resp = await fetch(`${osidbBaseUrl()}/osidb/api/v1/flaws`, {

--- a/pages/flawEdit.ts
+++ b/pages/flawEdit.ts
@@ -184,6 +184,7 @@ export class FlawEditPage extends FlawCreatePage {
       return;
     }
 
+    // 15 attempts with increasing delay: 1s, 2s, 3s, ... 15s (total max wait: 120s)
     for (let i = 0; i < 15; i++) {
       const flaw = await getFlawFromAPI(uuid, ['task_key']);
       if (flaw.task_key) {

--- a/playwright/cweData.ts
+++ b/playwright/cweData.ts
@@ -1,0 +1,36 @@
+/**
+ * Sample CWE data for autocomplete tests
+ * This data is loaded into localStorage to enable CWE autocomplete functionality
+ */
+export const cweTestData = [
+  {
+    id: '79',
+    name: 'Improper Neutralization of Input During Web Page Generation (\'Cross-site Scripting\')',
+    status: 'Stable',
+    summary: 'The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users.',
+    usage: 'Allowed',
+    category: '990',
+    isDiscouraged: false,
+    isProhibited: false,
+  },
+  {
+    id: '89',
+    name: 'Improper Neutralization of Special Elements used in an SQL Command',
+    status: 'Stable',
+    summary: 'The product constructs all or part of an SQL command using externally-influenced input from an upstream component.',
+    usage: 'Allowed',
+    category: '990',
+    isDiscouraged: false,
+    isProhibited: false,
+  },
+  {
+    id: '400',
+    name: 'Uncontrolled Resource Consumption',
+    status: 'Stable',
+    summary: 'The product does not properly control the allocation and maintenance of a limited resource.',
+    usage: 'Allowed',
+    category: '399',
+    isDiscouraged: false,
+    isProhibited: false,
+  },
+];

--- a/tests/acknowledgements.spec.ts
+++ b/tests/acknowledgements.spec.ts
@@ -17,7 +17,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill('John Doe');
     await page.getByLabel('Affiliation').fill('Security Research Inc.');
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();
@@ -29,7 +29,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill('Jane Smith');
     await page.getByLabel('Affiliation').fill('Original Company');
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();
@@ -62,7 +62,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill('Delete Me');
     await page.getByLabel('Affiliation').fill('Temporary Corp');
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();
@@ -85,7 +85,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill('Keep This Person');
     await page.getByLabel('Affiliation').fill('Permanent Company');
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();
@@ -124,7 +124,7 @@ test.describe('flaw acknowledgements', () => {
       await page.getByLabel('Name').fill(name);
       await page.getByLabel('Affiliation').fill(affiliation);
       await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-      await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
       // Refresh page to work around OSIM bug where acknowledgments remain in edit mode
       await page.reload();
@@ -143,7 +143,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill('UUID Test Person');
     await page.getByLabel('Affiliation').fill('UUID Test Corp');
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();
@@ -163,7 +163,7 @@ test.describe('flaw acknowledgements', () => {
     await page.getByLabel('Name').fill(testData.name);
     await page.getByLabel('Affiliation').fill(testData.affiliation);
     await page.getByRole('button', { name: 'Save Changes to Acknowledgments' }).click();
-    await expect(page.getByText('Acknowledgment created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Acknowledgment created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where acknowledgments remain in edit mode
     await page.reload();

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -81,7 +81,6 @@ setup('authenticate', async ({ baseURL }) => {
       {
         origin: baseURL ?? `${osimProtocol}://${osimUrl}`,
         localStorage: [
-          // AuthStore keys (new format)
           {
             name: 'AuthStore::isLoggedIn',
             value: 'true',

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -81,6 +81,7 @@ setup('authenticate', async ({ baseURL }) => {
       {
         origin: baseURL ?? `${osimProtocol}://${osimUrl}`,
         localStorage: [
+          // AuthStore keys (new format)
           {
             name: 'AuthStore::isLoggedIn',
             value: 'true',
@@ -89,6 +90,7 @@ setup('authenticate', async ({ baseURL }) => {
             name: 'AuthStore::refresh',
             value: refresh,
           },
+          // UserStore for user info
           {
             name: 'UserStore',
             value: JSON.stringify({

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,5 +1,6 @@
 import { test as setup } from '@playwright/test';
 import { authenticate, saveStorage, saveApiKeysToBackend } from '../playwright/helpers';
+import { cweTestData } from '../playwright/cweData';
 
 // Use http for localhost (CI), https otherwise
 const osimUrl = process.env.OSIM_URL || '';
@@ -125,6 +126,11 @@ setup('authenticate', async ({ baseURL }) => {
               bugzillaApiKey: process.env.BUGZILLA_API_KEY || 'fake-bz-key',
               jiraApiKey: process.env.JIRA_API_KEY || 'fake-jira-key',
             }),
+          },
+          {
+            // CWE data for autocomplete feature
+            name: 'CWE:API-DATA',
+            value: JSON.stringify(cweTestData),
           },
         ],
       },

--- a/tests/flaw.spec.ts
+++ b/tests/flaw.spec.ts
@@ -85,7 +85,7 @@ test.describe('flaw edition', () => {
   (['public', 'private'] as const).forEach((type: CommentType) => {
     test(`can add a ${type} comment`, async ({ page, flawEditPage }) => {
       await flawEditPage.addComment(type);
-      await expect(page.getByText(new RegExp(`${type} comment saved`, 'i'))).toBeVisible();
+      await expect(page.getByText(new RegExp(`${type} comment saved`, 'i')).first()).toBeVisible();
     });
   });
 
@@ -94,7 +94,7 @@ test.describe('flaw edition', () => {
     test.skip(!!process.env.CI, 'Internal comments require real Jira integration');
 
     await flawEditPage.addComment('internal');
-    await expect(page.getByText(new RegExp(`internal comment saved`, 'i'))).toBeVisible();
+    await expect(page.getByText(new RegExp(`internal comment saved`, 'i')).first()).toBeVisible();
   });
 
   test('jira link opens task in new page', async ({ flawEditPage, context }) => {
@@ -113,13 +113,13 @@ test.describe('flaw edition', () => {
   });
 
   test('can change the title', async ({ page, flawEditPage }) => {
-    const title = await flawEditPage.titleBox.locator('span', { hasNotText: 'Title' }).innerText();
+    const title = await flawEditPage.titleBox.locator('.osim-editable-text-value').innerText();
     const newTitle = title + ' edited';
 
     await flawEditPage.fillTextBox(flawEditPage.titleBox, newTitle);
     await flawEditPage.submitButton.click();
 
-    await expect(page.getByText('Flaw saved')).toBeVisible();
+    await expect(page.getByText('Flaw saved').first()).toBeVisible();
     await expect(page.getByText(newTitle, { exact: true })).toBeVisible();
   });
 
@@ -127,7 +127,7 @@ test.describe('flaw edition', () => {
     test('can add an affect', async ({ page, flawEditPage }) => {
       await flawEditPage.addAffect();
       await flawEditPage.submitButton.click();
-      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible();
+      await expect(page.getByText(/\d+ affects? created/i).first()).toBeVisible();
     });
   });
 });

--- a/tests/optionalFields.spec.ts
+++ b/tests/optionalFields.spec.ts
@@ -1,0 +1,466 @@
+import { test, expect } from '../playwright/fixtures';
+import { FlawCreatePage } from '../pages/flawCreate';
+import { faker } from '@faker-js/faker';
+
+test.describe('optional flaw fields', () => {
+  let flawId: string;
+
+  test.beforeAll(async () => {
+    flawId = await FlawCreatePage.createFlawWithAPI();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/flaws/${flawId}`);
+    await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+  });
+
+  test.describe('CVE ID', () => {
+    test('can add a CVE ID', async ({ page }) => {
+      const cveId = `CVE-${faker.number.int({ min: 2100, max: 2999 })}-${faker.number.int({ max: 9999 }).toString().padStart(4, '0')}`;
+      const cveIdField = page.locator('label').filter({ hasText: 'CVE ID' });
+
+      await cveIdField.click();
+      await cveIdField.getByRole('textbox').fill(cveId);
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      await expect(cveIdField.locator('.osim-editable-text-value')).toHaveText(cveId);
+    });
+
+    test('validates invalid CVE ID format', async ({ page }) => {
+      const cveIdField = page.locator('label').filter({ hasText: 'CVE ID' });
+
+      await cveIdField.click();
+      await cveIdField.getByRole('textbox').fill('invalid-cve');
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).focus();
+
+      await expect(page.getByText(/CVE ID is invalid/i)).toBeVisible();
+    });
+  });
+
+  test.describe('CWE ID', () => {
+    test('can add a CWE ID', async ({ page }) => {
+      const cweId = `CWE-${faker.number.int({ min: 1, max: 999 })}`;
+      const cweField = page.locator('.osim-input').filter({ hasText: 'CWE ID' });
+
+      await cweField.click();
+      await cweField.getByRole('textbox').fill(cweId);
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('can clear CWE ID', async ({ page }) => {
+      const cweField = page.locator('.osim-input').filter({ hasText: 'CWE ID' });
+
+      // First add a CWE ID
+      await cweField.click();
+      await cweField.getByRole('textbox').fill('CWE-79');
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+
+      // Then clear it
+      await cweField.click();
+      await cweField.getByRole('textbox').clear();
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('shows autocomplete suggestions when typing', async ({ page }) => {
+      const cweField = page.locator('.osim-input').filter({ hasText: 'CWE ID' });
+
+      await cweField.click();
+      const textbox = cweField.getByRole('textbox');
+      await textbox.clear();
+      // Type slowly to trigger debounced input
+      await textbox.pressSequentially('CWE-79', { delay: 100 });
+
+      // Wait for debounce (500ms) + suggestions to load - dropdown renders at page level
+      const suggestionsDropdown = page.locator('.menu.dropdown-menu');
+      await expect(suggestionsDropdown).toBeVisible({ timeout: 10000 });
+
+      // Verify suggestions contain CWE-79
+      await expect(suggestionsDropdown.locator('.item').filter({ hasText: 'CWE-79' })).toBeVisible();
+    });
+
+    test('can select CWE from autocomplete suggestions', async ({ page }) => {
+      const cweField = page.locator('.osim-input').filter({ hasText: 'CWE ID' });
+
+      await cweField.click();
+      const textbox = cweField.getByRole('textbox');
+      await textbox.clear();
+      // Type slowly to trigger debounced input
+      await textbox.pressSequentially('CWE-79', { delay: 100 });
+
+      // Wait for suggestions dropdown to appear - dropdown renders at page level
+      const suggestionsDropdown = page.locator('.menu.dropdown-menu');
+      await expect(suggestionsDropdown).toBeVisible({ timeout: 10000 });
+
+      // Click the suggestion
+      const suggestion = suggestionsDropdown.locator('.item').filter({ hasText: 'CWE-79' }).first();
+      await suggestion.click();
+
+      // Verify the field was filled
+      await expect(cweField.locator('.osim-editable-text-value')).toHaveText('CWE-79');
+
+      // Save and verify
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+  });
+
+  test.describe('Incident State', () => {
+    // Incident State field is only editable if the flaw already has one set
+    // Each test creates its own flaw to avoid workflow transition conflicts
+    const incidentStateTransitions = [
+      { initial: 'MINOR_INCIDENT_REQUESTED', target: 'Minor Incident Approved' },
+      { initial: 'MAJOR_INCIDENT_REQUESTED', target: 'Major Incident Approved' },
+    ];
+
+    for (const { initial, target } of incidentStateTransitions) {
+      test(`can set ${target}`, async ({ page }) => {
+        // Create a fresh flaw with the initial incident state
+        const incidentFlawId = await FlawCreatePage.createFlawWithAPI({
+          major_incident_state: initial,
+        });
+
+        // Navigate to the flaw
+        await page.goto(`/flaws/${incidentFlawId}`);
+        await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+
+        const incidentField = page.locator('label').filter({ hasText: 'Incident State' });
+        const selectElement = incidentField.locator('select');
+
+        await incidentField.click();
+        await selectElement.selectOption({ label: target });
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      });
+    }
+  });
+
+  test.describe('Statement', () => {
+    test('can add a statement', async ({ page }) => {
+      const statement = faker.lorem.paragraph();
+      const statementField = page.locator('label').filter({ hasText: 'Statement' });
+
+      await statementField.click();
+      await statementField.getByRole('textbox').fill(statement);
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('can clear statement', async ({ page }) => {
+      const statementField = page.locator('label').filter({ hasText: 'Statement' });
+
+      await statementField.click();
+      await statementField.getByRole('textbox').clear();
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+  });
+
+  test.describe('Mitigation', () => {
+    test('can add a mitigation', async ({ page }) => {
+      const mitigation = faker.lorem.paragraph();
+      const mitigationField = page.locator('label').filter({ hasText: 'Mitigation' });
+
+      await mitigationField.click();
+      await mitigationField.getByRole('textbox').fill(mitigation);
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('can clear mitigation', async ({ page }) => {
+      const mitigationField = page.locator('label').filter({ hasText: 'Mitigation' });
+
+      // First add a mitigation value
+      await mitigationField.click();
+      await mitigationField.getByRole('textbox').fill('Temporary mitigation');
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+
+      // Then clear it
+      await mitigationField.click();
+      await mitigationField.getByRole('textbox').clear();
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+  });
+
+  test.describe('Description', () => {
+    test('can add a description', async ({ page }) => {
+      const description = faker.lorem.paragraph();
+      const descriptionField = page.locator('label').filter({ hasText: 'Description' }).first();
+
+      await descriptionField.click();
+      await descriptionField.getByRole('textbox').fill(description);
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('can set review status', async ({ page }) => {
+      const reviewStatuses = ['REQUESTED', 'APPROVED', 'REJECTED'];
+
+      for (const status of reviewStatuses) {
+        await page.locator('select.osim-description-required').selectOption(status);
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      }
+    });
+  });
+
+  test.describe('Reported Date', () => {
+    test('can set reported date', async ({ page }) => {
+      const reportedDateField = page.locator('label').filter({ hasText: 'Reported Date' });
+
+      await reportedDateField.click();
+      const dateInput = reportedDateField.getByRole('textbox');
+      await dateInput.clear();
+      await dateInput.fill('2024-01-15');
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+
+    test('can change reported date', async ({ page }) => {
+      const reportedDateField = page.locator('label').filter({ hasText: 'Reported Date' });
+
+      // Reported Date is required, so we change it to a different date instead of clearing
+      await reportedDateField.click();
+      await reportedDateField.getByRole('textbox').fill('2024-01-15');
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+  });
+
+  test.describe('Owner', () => {
+    test('can self-assign as owner', async ({ page }) => {
+      const selfAssignBtn = page.getByRole('button', { name: 'Self Assign' });
+
+      if (await selfAssignBtn.isVisible()) {
+        await selfAssignBtn.click();
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      }
+    });
+
+    test('can unassign owner', async ({ page }) => {
+      const unassignBtn = page.getByRole('button', { name: 'Unassign' });
+
+      if (await unassignBtn.isVisible()) {
+        await unassignBtn.click();
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      }
+    });
+  });
+
+  test.describe('CVSS Calculator', () => {
+    test('can set CVSS score via calculator', async ({ page }) => {
+      // CVSS label uses role="red-hat-cvss" and text is either 'CVSS' or 'CVSSv3'
+      const cvssInput = page.locator('label[role="red-hat-cvss"]');
+      await cvssInput.click();
+
+      const cvssCalculator = page.locator('.cvss-calculator');
+      await expect(cvssCalculator).toBeVisible();
+
+      // Set each CVSS metric
+      const metrics = [
+        'Attack Vector',
+        'Attack Complexity',
+        'Privileges Required',
+        'User Interaction',
+        'Scope',
+        'Confidentiality',
+        'Integrity',
+        'Availability',
+      ];
+
+      for (const metric of metrics) {
+        const metricSection = cvssCalculator.locator('div', { hasText: metric }).last();
+        const buttons = metricSection.locator('button').filter({ hasNotText: metric });
+        const buttonCount = await buttons.count();
+
+        if (buttonCount > 1) {
+          await buttons.nth(1).scrollIntoViewIfNeeded();
+          await buttons.nth(1).click();
+        }
+      }
+
+      // CVSS is saved when clicking Save Changes button
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      // Wait for the CVSS-specific success toast
+      await expect(page.locator('.osim-toast-container').getByText('Saved CVSS Scores')).toBeVisible({ timeout: 15000 });
+    });
+
+    test('can set CVSS score via vector string', async ({ page }) => {
+      const cvssVector = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H';
+      const cvssField = page.locator('label[role="red-hat-cvss"]');
+
+      // Click to focus and open calculator
+      await cvssField.click();
+
+      // Find the vector input and dispatch a paste event with the CVSS vector
+      const vectorInput = cvssField.locator('.vector-input');
+      await vectorInput.click();
+
+      // Dispatch paste event directly (CVSS calculator has handlePaste)
+      await vectorInput.evaluate((el, vector) => {
+        const pasteEvent = new ClipboardEvent('paste', {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: new DataTransfer(),
+        });
+        pasteEvent.clipboardData?.setData('text', vector);
+        el.dispatchEvent(pasteEvent);
+      }, cvssVector);
+
+      // Save changes
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      // Wait for the CVSS-specific success toast
+      await expect(page.locator('.osim-toast-container').getByText('Saved CVSS Scores')).toBeVisible({ timeout: 15000 });
+    });
+
+    test('can clear CVSS score using erase button', async ({ page }) => {
+      const cvssField = page.locator('label[role="red-hat-cvss"]');
+
+      // First set a CVSS score if not already set
+      await cvssField.click();
+      const cvssCalculator = page.locator('.cvss-calculator');
+      await expect(cvssCalculator).toBeVisible();
+
+      // Click on first option for each metric to ensure we have a valid score
+      const metrics = ['Attack Vector', 'Attack Complexity', 'Privileges Required', 'User Interaction', 'Scope', 'Confidentiality', 'Integrity', 'Availability'];
+      for (const metric of metrics) {
+        const metricSection = cvssCalculator.locator('div', { hasText: metric }).last();
+        const buttons = metricSection.locator('button').filter({ hasNotText: metric });
+        if (await buttons.count() > 0) {
+          await buttons.first().scrollIntoViewIfNeeded();
+          await buttons.first().click();
+        }
+      }
+
+      // Save the initial score
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      await expect(page.locator('.osim-toast-container').getByText('Saved CVSS Scores')).toBeVisible({ timeout: 15000 });
+
+      // Now clear the CVSS score using the erase button
+      const eraseButton = page.locator('.erase-button');
+      await eraseButton.click();
+
+      // Save the cleared score
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      // Verify score was deleted
+      await expect(page.locator('.osim-toast-container').getByText('CVSS score deleted')).toBeVisible({ timeout: 15000 });
+    });
+  });
+
+  test.describe('Source', () => {
+    const sources = ['REDHAT', 'CUSTOMER', 'RESEARCHER', 'INTERNET'];
+
+    for (const source of sources) {
+      test(`can set source to ${source}`, async ({ page }) => {
+        const sourceField = page.locator('label').filter({ hasText: 'CVE Source' });
+        const selectElement = sourceField.locator('select');
+
+        // First change to a different value to ensure there's always a change
+        const currentValue = await selectElement.inputValue();
+        if (currentValue === source) {
+          const otherSource = sources.find(s => s !== source) ?? 'CUSTOMER';
+          await sourceField.click();
+          await selectElement.selectOption(otherSource);
+          await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+          await expect(page.getByText('Flaw saved').first()).toBeVisible();
+        }
+
+        // Now set to target value
+        await sourceField.click();
+        await selectElement.selectOption(source);
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      });
+    }
+  });
+
+  test.describe('Impact', () => {
+    const impacts = ['LOW', 'MODERATE', 'IMPORTANT', 'CRITICAL'];
+
+    for (const impact of impacts) {
+      test(`can set impact to ${impact}`, async ({ page }) => {
+        // Use .first() to target flaw form's Impact, not the one in Affected Offerings
+        const impactField = page.locator('label').filter({ hasText: 'Impact' }).first();
+        const selectElement = impactField.locator('select');
+
+        // First change to a different value to ensure there's always a change
+        const currentValue = await selectElement.inputValue();
+        if (currentValue === impact) {
+          const otherImpact = impacts.find(i => i !== impact) ?? 'LOW';
+          await impactField.click();
+          await selectElement.selectOption(otherImpact);
+          await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+          await expect(page.getByText('Flaw saved').first()).toBeVisible();
+        }
+
+        // Now set to target value
+        await impactField.click();
+        await selectElement.selectOption(impact);
+        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+        await expect(page.getByText('Flaw saved').first()).toBeVisible();
+      });
+    }
+  });
+
+  test.describe('Embargoed status', () => {
+    let embargoedFlawId: string;
+
+    test.beforeAll(async () => {
+      // Create an embargoed flaw specifically for this test
+      embargoedFlawId = await FlawCreatePage.createFlawWithAPI({ embargoed: true });
+    });
+
+    test('can unembargo an embargoed flaw', async ({ page }) => {
+      // Navigate to the embargoed flaw
+      await page.goto(`/flaws/${embargoedFlawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+
+      // For existing flaws, embargo status shows as "Yes/No" text with an "Unembargo" button
+      // (no checkbox - that's only for new flaws)
+      const embargoedField = page.locator('.osim-embargo-label');
+
+      // Click Unembargo button
+      await page.getByRole('button', { name: 'Unembargo' }).click();
+
+      // The field should now show warning state (pending unembargo)
+      await expect(embargoedField.locator('.form-control')).toContainText('No');
+
+      // Save changes
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      // Confirmation modal appears for unembargo
+      await expect(page.getByText('Set Flaw for Unembargo')).toBeVisible();
+
+      // Type the flaw ID (UUID) to confirm
+      await page.getByLabel('Confirm').fill(embargoedFlawId);
+      await page.getByRole('button', { name: 'Remove Embargo' }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
+    });
+  });
+});

--- a/tests/optionalFields.spec.ts
+++ b/tests/optionalFields.spec.ts
@@ -299,37 +299,38 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Owner', () => {
-    let flawId: string;
-
-    test.beforeAll(async () => {
-      flawId = await FlawCreatePage.createFlawWithAPI();
-    });
-
-    test.beforeEach(async ({ page }) => {
+    test('can self-assign as owner', async ({ page }) => {
+      // Create flaw without owner so Self Assign button is visible
+      const flawId = await FlawCreatePage.createFlawWithAPI({ withOwner: false });
       await page.goto(`/flaws/${flawId}`);
       await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
-    });
 
-    test('can self-assign as owner', async ({ page }) => {
       const selfAssignBtn = page.getByRole('button', { name: 'Self Assign' });
 
-      if (await selfAssignBtn.isVisible()) {
-        await selfAssignBtn.click();
-        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      // Assert button should be visible for this flaw state
+      await expect(selfAssignBtn).toBeVisible();
 
-        await expect(page.getByText('Flaw saved').first()).toBeVisible();
-      }
+      await selfAssignBtn.click();
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
     });
 
     test('can unassign owner', async ({ page }) => {
+      // Create flaw with owner so Unassign button is visible
+      const flawId = await FlawCreatePage.createFlawWithAPI({ withOwner: true });
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+
       const unassignBtn = page.getByRole('button', { name: 'Unassign' });
 
-      if (await unassignBtn.isVisible()) {
-        await unassignBtn.click();
-        await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+      // Assert button should be visible for this flaw state
+      await expect(unassignBtn).toBeVisible();
 
-        await expect(page.getByText('Flaw saved').first()).toBeVisible();
-      }
+      await unassignBtn.click();
+      await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+
+      await expect(page.getByText('Flaw saved').first()).toBeVisible();
     });
   });
 

--- a/tests/optionalFields.spec.ts
+++ b/tests/optionalFields.spec.ts
@@ -3,18 +3,18 @@ import { FlawCreatePage } from '../pages/flawCreate';
 import { faker } from '@faker-js/faker';
 
 test.describe('optional flaw fields', () => {
-  let flawId: string;
-
-  test.beforeAll(async () => {
-    flawId = await FlawCreatePage.createFlawWithAPI();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await page.goto(`/flaws/${flawId}`);
-    await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
-  });
-
   test.describe('CVE ID', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can add a CVE ID', async ({ page }) => {
       const cveId = `CVE-${faker.number.int({ min: 2100, max: 2999 })}-${faker.number.int({ max: 9999 }).toString().padStart(4, '0')}`;
       const cveIdField = page.locator('label').filter({ hasText: 'CVE ID' });
@@ -39,6 +39,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('CWE ID', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can add a CWE ID', async ({ page }) => {
       const cweId = `CWE-${faker.number.int({ min: 1, max: 999 })}`;
       const cweField = page.locator('.osim-input').filter({ hasText: 'CWE ID' });
@@ -142,6 +153,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Statement', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can add a statement', async ({ page }) => {
       const statement = faker.lorem.paragraph();
       const statementField = page.locator('label').filter({ hasText: 'Statement' });
@@ -165,6 +187,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Mitigation', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can add a mitigation', async ({ page }) => {
       const mitigation = faker.lorem.paragraph();
       const mitigationField = page.locator('label').filter({ hasText: 'Mitigation' });
@@ -195,6 +228,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Description', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can add a description', async ({ page }) => {
       const description = faker.lorem.paragraph();
       const descriptionField = page.locator('label').filter({ hasText: 'Description' }).first();
@@ -219,6 +263,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Reported Date', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can set reported date', async ({ page }) => {
       const reportedDateField = page.locator('label').filter({ hasText: 'Reported Date' });
 
@@ -244,6 +299,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Owner', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can self-assign as owner', async ({ page }) => {
       const selfAssignBtn = page.getByRole('button', { name: 'Self Assign' });
 
@@ -268,6 +334,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('CVSS Calculator', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     test('can set CVSS score via calculator', async ({ page }) => {
       // CVSS label uses role="red-hat-cvss" and text is either 'CVSS' or 'CVSSv3'
       const cvssInput = page.locator('label[role="red-hat-cvss"]');
@@ -371,6 +448,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Source', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     const sources = ['REDHAT', 'CUSTOMER', 'RESEARCHER', 'INTERNET'];
 
     for (const source of sources) {
@@ -399,6 +487,17 @@ test.describe('optional flaw fields', () => {
   });
 
   test.describe('Impact', () => {
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`/flaws/${flawId}`);
+      await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible();
+    });
+
     const impacts = ['LOW', 'MODERATE', 'IMPORTANT', 'CRITICAL'];
 
     for (const impact of impacts) {

--- a/tests/references.spec.ts
+++ b/tests/references.spec.ts
@@ -18,7 +18,7 @@ test.describe('flaw references', () => {
     await page.locator('.osim-cancel-new-reference').locator('..').getByLabel('Description').fill('Test security advisory reference');
     await page.getByLabel('Reference type').selectOption('EXTERNAL');
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
-    await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('can edit an existing reference', async ({ page }) => {
@@ -27,7 +27,7 @@ test.describe('flaw references', () => {
     await page.locator('.osim-cancel-new-reference').locator('..').getByLabel('Description').fill('Original description');
     await page.getByLabel('Reference type').selectOption('UPSTREAM');
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
-    await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where references remain in edit mode
     await page.reload();
@@ -60,7 +60,7 @@ test.describe('flaw references', () => {
     await page.locator('.osim-cancel-new-reference').locator('..').getByLabel('Description').fill('Reference to be deleted');
     await page.getByLabel('Reference type').selectOption('EXTERNAL');
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
-    await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where references remain in edit mode
     await page.reload();
@@ -85,7 +85,7 @@ test.describe('flaw references', () => {
     await page.locator('.osim-cancel-new-reference').locator('..').getByLabel('Description').fill('Reference to keep');
     await page.getByLabel('Reference type').selectOption('UPSTREAM');
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
-    await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where references remain in edit mode
     await page.reload();
@@ -113,7 +113,7 @@ test.describe('flaw references', () => {
     await page.getByLabel('Reference type').selectOption('EXTERNAL');
     await page.getByRole('button', { name: 'Save Changes to References' }).click();
 
-    await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
 
     // Work around OSIM bug where references remain in edit mode
     await page.reload();
@@ -141,7 +141,7 @@ test.describe('flaw references', () => {
       await page.locator('.osim-cancel-new-reference').locator('..').getByLabel('Description').fill(`${type} reference`);
       await page.getByLabel('Reference type').selectOption(type);
       await page.getByRole('button', { name: 'Save Changes to References' }).click();
-      await expect(page.getByText('Reference created.')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText('Reference created.').first()).toBeVisible({ timeout: 10000 });
 
       // Work around OSIM bug where references remain in edit mode
       await page.reload();


### PR DESCRIPTION
Extends coverage of integration tests by including optional flaw fields:
- CVE ID: add, validate format
- CWE ID: add, clear, autocomplete, select suggestion
- Incident State: set Minor/Major Incident Approved
- Statement: add, clear
- Mitigation: add, clear
- Description: add, set review status
- Reported Date: set, change
- Owner: self-assign, unassign
- CVSS Calculator: set via calculator, paste vector, clear
- Source: set to various values (REDHAT, CUSTOMER, etc.)
- Impact: set to various values (LOW, MODERATE, etc.)
- Embargoed status: unembargo flaw

Also adds data for CWE auto-completion:
- Sample CWE entries (79, 89, 400) for autocomplete tests
- Loaded into localStorage via auth setup

## Considerations
- Depends on https://github.com/RedHatProductSecurity/osim-ui-tests/pull/10