### PR TITLE
✨ Advance search coverage

### DIFF
--- a/pages/flawSearch.ts
+++ b/pages/flawSearch.ts
@@ -1,0 +1,307 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class FlawSearchPage {
+  // Advanced Search container
+  readonly advancedSearchDetails: Locator;
+  readonly advancedSearchSummary: Locator;
+
+  // Query Filter
+  readonly queryFilterContainer: Locator;
+  readonly queryFilterInput: Locator;
+  readonly queryFilterClearButton: Locator;
+  readonly queryFilterHideButton: Locator;
+  readonly queryFilterGuideButton: Locator;
+  readonly showQueryFilterButton: Locator;
+
+  // Search facets (field/value pairs)
+  readonly facetRows: Locator;
+  readonly searchButton: Locator;
+
+  // Sorting
+  readonly sortBySelect: Locator;
+  readonly sortOrderButton: Locator;
+
+  // Saved Searches
+  readonly savedSearchesDetails: Locator;
+  readonly savedSearchesSummary: Locator;
+  readonly savedSearchButtons: Locator;
+  readonly saveSearchButton: Locator;
+  readonly updateSearchButton: Locator;
+  readonly deleteSearchButton: Locator;
+  readonly noSavedSearchesText: Locator;
+
+  // Save Search Modal
+  readonly saveSearchModal: Locator;
+  readonly searchNameInput: Locator;
+  readonly modalSaveButton: Locator;
+  readonly modalCloseButton: Locator;
+
+  // Results
+  readonly loadedIndicator: Locator;
+  readonly resultsTable: Locator;
+  readonly resultRows: Locator;
+
+  constructor(public readonly page: Page) {
+    // Advanced Search container
+    this.advancedSearchDetails = page.locator('details.osim-advanced-search-container').first();
+    this.advancedSearchSummary = this.advancedSearchDetails.locator('summary');
+
+    // Query Filter - locate textbox in the main content area (not header search)
+    this.queryFilterInput = page.locator('main').getByRole('textbox').first();
+    // Container visibility tracked by the textbox (hidden when query filter is collapsed)
+    this.queryFilterContainer = this.queryFilterInput;
+    this.queryFilterClearButton = page.locator('button[title="Clear query"]');
+    this.queryFilterHideButton = page.getByRole('button', { name: 'hide query filter' }).first();
+    this.queryFilterGuideButton = page.locator('.query-input button');
+    this.showQueryFilterButton = page.getByRole('button', { name: 'Show Query Filter' });
+
+    // Search facets - rows contain field selector (first select) and value input/select
+    // Don't filter by input since dropdown fields replace input with a second select
+    this.facetRows = page.locator('.input-group').filter({ has: page.locator('select') });
+    // Advanced Search button (aria-label distinguishes from header search)
+    this.searchButton = page.getByRole('button', { name: 'Advance search button' });
+
+    // Sorting
+    this.sortBySelect = page.locator('select.sort-by-select');
+    this.sortOrderButton = page.locator('button.sort-by-order');
+
+    // Saved Searches
+    this.savedSearchesDetails = page.locator('details.osim-advanced-search-container').nth(1);
+    this.savedSearchesSummary = this.savedSearchesDetails.locator('summary');
+    this.savedSearchButtons = this.savedSearchesDetails.locator('.container-fluid button');
+    this.saveSearchButton = page.getByRole('button', { name: 'Save Search' });
+    this.updateSearchButton = page.getByRole('button', { name: 'Update Search' });
+    this.deleteSearchButton = page.getByRole('button', { name: 'Delete Search' });
+    this.noSavedSearchesText = page.getByText('No saved searches');
+
+    // Save Search Modal
+    this.saveSearchModal = page.locator('.modal');
+    this.searchNameInput = page.locator('.modal input[placeholder="Search Name"]');
+    this.modalSaveButton = page.locator('.modal').getByRole('button', { name: 'Save' });
+    this.modalCloseButton = page.locator('.modal').getByRole('button', { name: 'Close' });
+
+    // Results - use partial match to be more flexible
+    this.loadedIndicator = page.getByText(/Loaded \d+ of \d+/);
+    this.resultsTable = page.locator('table');
+    this.resultRows = page.locator('table tbody tr');
+  }
+
+  async goto() {
+    await this.page.goto('/');
+    await this.loadedIndicator.waitFor({ state: 'visible' });
+  }
+
+  async gotoSearchPage() {
+    await this.page.goto('/search');
+    await this.page.waitForLoadState('networkidle');
+    // Wait for the search button to be visible (indicates page is ready)
+    await this.searchButton.waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  /**
+   * Enter a DjangoQL query in the query filter input
+   */
+  async enterQuery(query: string) {
+    await this.queryFilterInput.click();
+    await this.queryFilterInput.fill(query);
+  }
+
+  /**
+   * Clear the query filter input
+   */
+  async clearQuery() {
+    await this.queryFilterClearButton.click();
+  }
+
+  /**
+   * Submit the search
+   */
+  async search() {
+    await this.searchButton.click();
+    await this.loadedIndicator.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Enter a query and submit the search
+   */
+  async searchWithQuery(query: string) {
+    await this.enterQuery(query);
+    await this.search();
+  }
+
+  /**
+   * Get the number of facet rows currently displayed
+   */
+  async getFacetCount(): Promise<number> {
+    return await this.facetRows.count();
+  }
+
+  /**
+   * Select a field in a specific facet row (0-indexed)
+   */
+  async selectFacetField(rowIndex: number, fieldName: string) {
+    const row = this.facetRows.nth(rowIndex);
+    // First select in the row is the field selector
+    const select = row.locator('select').first();
+    await select.selectOption({ label: fieldName });
+  }
+
+  /**
+   * Enter a value in a specific facet row (0-indexed)
+   */
+  async enterFacetValue(rowIndex: number, value: string) {
+    const row = this.facetRows.nth(rowIndex);
+    const input = row.locator('input').first();
+    await input.fill(value);
+  }
+
+  /**
+   * Select a value from dropdown in a specific facet row (for fields with predefined options)
+   */
+  async selectFacetValue(rowIndex: number, value: string) {
+    const row = this.facetRows.nth(rowIndex);
+    // Second select in the row is the value selector (for dropdown fields like Impact, Source)
+    const select = row.locator('select').nth(1);
+    // Wait for the value dropdown to appear after field selection
+    await select.waitFor({ state: 'visible', timeout: 10000 });
+    await select.selectOption(value);
+  }
+
+  /**
+   * Click the "empty" button for a facet (sets value to 'isempty')
+   */
+  async setFacetEmpty(rowIndex: number) {
+    const row = this.facetRows.nth(rowIndex);
+    await row.locator('button[title="Empty field search"]').click();
+  }
+
+  /**
+   * Click the "non-empty" button for a facet (sets value to 'nonempty')
+   */
+  async setFacetNonEmpty(rowIndex: number) {
+    const row = this.facetRows.nth(rowIndex);
+    await row.locator('button[title="Non empty field search"]').click();
+  }
+
+  /**
+   * Clear a facet value
+   */
+  async clearFacetValue(rowIndex: number) {
+    const row = this.facetRows.nth(rowIndex);
+    await row.locator('button[title="Clear field"]').click();
+  }
+
+  /**
+   * Remove a facet row
+   */
+  async removeFacet(rowIndex: number) {
+    const row = this.facetRows.nth(rowIndex);
+    await row.locator('button.btn-primary').last().click();
+  }
+
+  /**
+   * Add a facet with field and value
+   */
+  async addFacet(fieldName: string, value: string) {
+    const facetCount = await this.getFacetCount();
+    // The last facet row should be empty (for adding new facets)
+    const lastRowIndex = facetCount - 1;
+    await this.selectFacetField(lastRowIndex, fieldName);
+    await this.enterFacetValue(lastRowIndex, value);
+  }
+
+  /**
+   * Add a facet with field and select a predefined value
+   */
+  async addFacetWithSelect(fieldName: string, value: string) {
+    const facetCount = await this.getFacetCount();
+    const lastRowIndex = facetCount - 1;
+    await this.selectFacetField(lastRowIndex, fieldName);
+    await this.selectFacetValue(lastRowIndex, value);
+  }
+
+  /**
+   * Set the sort field
+   */
+  async setSortField(fieldLabel: string) {
+    await this.sortBySelect.selectOption({ label: fieldLabel });
+  }
+
+  /**
+   * Toggle the sort order (asc/desc)
+   */
+  async toggleSortOrder() {
+    await this.sortOrderButton.click();
+  }
+
+  /**
+   * Get the current sort order ('asc' or 'desc')
+   */
+  async getSortOrder(): Promise<'asc' | 'desc'> {
+    const icon = this.sortOrderButton.locator('i');
+    const hasAscClass = await icon.evaluate(el => el.classList.contains('bi-caret-up-fill'));
+    return hasAscClass ? 'asc' : 'desc';
+  }
+
+  /**
+   * Save the current search with a name
+   */
+  async saveSearch(name: string) {
+    await this.saveSearchButton.click();
+    await this.searchNameInput.fill(name);
+    await this.modalSaveButton.click();
+  }
+
+  /**
+   * Select a saved search by name
+   */
+  async selectSavedSearch(name: string) {
+    await this.savedSearchesDetails.getByRole('button', { name }).click();
+  }
+
+  /**
+   * Delete the currently selected saved search
+   */
+  async deleteCurrentSavedSearch() {
+    await this.deleteSearchButton.click();
+  }
+
+  /**
+   * Set a saved search as default
+   */
+  async setDefaultSearch(name: string) {
+    const button = this.savedSearchesDetails.getByRole('button', { name });
+    await button.locator('i').click();
+  }
+
+  /**
+   * Get the number of results displayed
+   */
+  async getResultCount(): Promise<number> {
+    return await this.resultRows.count();
+  }
+
+  /**
+   * Get a specific column value from a result row
+   */
+  async getResultColumnValue(rowIndex: number, columnIndex: number): Promise<string> {
+    const row = this.resultRows.nth(rowIndex);
+    const cell = row.locator('td').nth(columnIndex);
+    return await cell.innerText();
+  }
+
+  /**
+   * Check if a specific text appears in the results
+   */
+  async resultsContainText(text: string): Promise<boolean> {
+    const count = await this.resultsTable.getByText(text).count();
+    return count > 0;
+  }
+
+  /**
+   * Wait for search results to load
+   */
+  async waitForResults() {
+    await this.loadedIndicator.waitFor({ state: 'visible' });
+  }
+}

--- a/playwright/fixtures.ts
+++ b/playwright/fixtures.ts
@@ -1,10 +1,12 @@
 import { test as base } from '@playwright/test';
 import { FlawCreatePage } from '../pages/flawCreate';
 import { FlawEditPage } from '../pages/flawEdit';
+import { FlawSearchPage } from '../pages/flawSearch';
 
 interface Fixtures {
   flawCreatePage: FlawCreatePage;
   flawEditPage: FlawEditPage;
+  flawSearchPage: FlawSearchPage;
 }
 
 export const test = base.extend<Fixtures>({
@@ -18,6 +20,12 @@ export const test = base.extend<Fixtures>({
     const flawEditPage = new FlawEditPage(page);
 
     await use(flawEditPage);
+  },
+  flawSearchPage: async ({ page }, use) => {
+    const flawSearchPage = new FlawSearchPage(page);
+    await flawSearchPage.gotoSearchPage();
+
+    await use(flawSearchPage);
   },
 });
 

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,0 +1,383 @@
+import { FlawCreatePage } from '../pages/flawCreate';
+import { test, expect } from '../playwright/fixtures';
+
+const testRunId = Math.random().toString(36).substring(2, 8).toUpperCase();
+
+test.describe('advanced search', () => {
+  test.beforeAll(async () => {
+    await Promise.all([
+      FlawCreatePage.createFlawWithAPI(),
+      FlawCreatePage.createFlawWithAPI(),
+      FlawCreatePage.createFlawWithAPI(),
+    ]);
+  });
+
+  test.beforeEach(async ({ flawSearchPage }) => {
+    await flawSearchPage.waitForResults();
+  });
+
+  test.describe('facet-based search', () => {
+    test('can search by title field', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacet('Title', 'Test flaw');
+      await flawSearchPage.search();
+      expect(await flawSearchPage.getResultCount()).toBeGreaterThan(0);
+    });
+
+    test('can search by impact field', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('Impact', 'LOW');
+      await flawSearchPage.search();
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can search by CVE Source field', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.search();
+      expect(await flawSearchPage.getResultCount()).toBeGreaterThan(0);
+    });
+
+    test('can search by Flaw State field', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('Flaw State', 'NEW');
+      await flawSearchPage.search();
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can search by embargoed field', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('Embargoed', 'false');
+      await flawSearchPage.search();
+      expect(await flawSearchPage.getResultCount()).toBeGreaterThan(0);
+    });
+
+    test('can combine multiple facet fields', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.addFacetWithSelect('Embargoed', 'false');
+      await flawSearchPage.search();
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can clear a facet value', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacet('Title', 'test');
+      await flawSearchPage.clearFacetValue(0);
+      const input = flawSearchPage.facetRows.first().locator('input.form-control');
+      await expect(input).toHaveValue('');
+    });
+
+    test('can remove a facet row', async ({ flawSearchPage }) => {
+      const initialCount = await flawSearchPage.getFacetCount();
+      await flawSearchPage.addFacet('Title', 'test');
+      const afterAddCount = await flawSearchPage.getFacetCount();
+      expect(afterAddCount).toBeGreaterThanOrEqual(initialCount);
+
+      await flawSearchPage.removeFacet(0);
+      expect(await flawSearchPage.getFacetCount()).toBeLessThan(afterAddCount);
+    });
+  });
+
+  test.describe('emptiness checks', () => {
+    test('can search for flaws with empty CVE ID', async ({ flawSearchPage }) => {
+      await flawSearchPage.selectFacetField(0, 'CVE ID');
+      await flawSearchPage.setFacetEmpty(0);
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can search for flaws with non-empty CVE ID', async ({ flawSearchPage }) => {
+      await flawSearchPage.selectFacetField(0, 'CVE ID');
+      await flawSearchPage.setFacetNonEmpty(0);
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can search for flaws with empty owner', async ({ flawSearchPage }) => {
+      await flawSearchPage.selectFacetField(0, 'Owner');
+      await flawSearchPage.setFacetEmpty(0);
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can search for flaws with empty CWE ID', async ({ flawSearchPage }) => {
+      await flawSearchPage.selectFacetField(0, 'CWE ID');
+      await flawSearchPage.setFacetEmpty(0);
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+  });
+
+  test.describe('query filter (DjangoQL)', () => {
+    test('can enter and submit a query', async ({ flawSearchPage }) => {
+      await flawSearchPage.searchWithQuery('source = "REDHAT"');
+      expect(await flawSearchPage.getResultCount()).toBeGreaterThanOrEqual(0);
+    });
+
+    test('can clear the query filter', async ({ flawSearchPage }) => {
+      await flawSearchPage.enterQuery('title ~ "test"');
+      await flawSearchPage.clearQuery();
+      await expect(flawSearchPage.queryFilterClearButton).toBeDisabled();
+    });
+
+    test.describe('comparison operators', () => {
+      test('equals operator (=)', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source = "REDHAT"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('not equals operator (!=)', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source != "INTERNET"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('contains operator (~)', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('title ~ "Test"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('not contains operator (!~)', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('title !~ "nonexistent"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('startswith operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('title startswith "Test"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('endswith operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('title endswith "flaw"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('in operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source in ("REDHAT", "INTERNET")');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('not in operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source not in ("APPLE", "GOOGLE")');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+    });
+
+    test.describe('logical operators', () => {
+      test('and operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source = "REDHAT" and embargoed = False');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('or operator', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source = "REDHAT" or source = "INTERNET"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('parentheses for grouping', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('(source = "REDHAT" or source = "INTERNET") and embargoed = False');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('complex query with multiple operators', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('source = "REDHAT" and (title ~ "Test" or title ~ "flaw")');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+    });
+
+    test.describe('special values', () => {
+      test('boolean True value', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('embargoed = True');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('boolean False value', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('embargoed = False');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('None value for empty fields', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('cve_id = None');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+    });
+
+    test.describe('field-specific queries', () => {
+      test('search by workflow_state', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('workflow_state = "NEW"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('search by impact', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('impact in ("LOW", "MODERATE", "IMPORTANT", "CRITICAL")');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+
+      test('search by affects.ps_module', async ({ flawSearchPage }) => {
+        await flawSearchPage.searchWithQuery('affects.ps_module ~ "rhel"');
+        await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      });
+    });
+  });
+
+  test.describe('sorting', () => {
+    test('can sort by CVSS Score', async ({ flawSearchPage }) => {
+      await flawSearchPage.setSortField('CVSS Score');
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+      await expect(flawSearchPage.sortOrderButton).toBeVisible();
+    });
+
+    test('can sort by CWE ID', async ({ flawSearchPage }) => {
+      await flawSearchPage.setSortField('CWE ID');
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can sort by CVE Source', async ({ flawSearchPage }) => {
+      await flawSearchPage.setSortField('CVE Source');
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can sort by Incident State', async ({ flawSearchPage }) => {
+      await flawSearchPage.setSortField('Incident State');
+      await flawSearchPage.search();
+
+      await expect(flawSearchPage.loadedIndicator).toBeVisible();
+    });
+
+    test('can toggle sort order', async ({ flawSearchPage }) => {
+      await flawSearchPage.setSortField('CVSS Score');
+      await flawSearchPage.search();
+
+      const initialOrder = await flawSearchPage.getSortOrder();
+      await flawSearchPage.toggleSortOrder();
+      await flawSearchPage.waitForResults();
+
+      const newOrder = await flawSearchPage.getSortOrder();
+      expect(newOrder).not.toEqual(initialOrder);
+    });
+  });
+
+  test.describe('saved searches', () => {
+    const savedSearchName = `Test Search ${testRunId}`;
+
+    test('can save a search', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.saveSearch(savedSearchName);
+      await expect(flawSearchPage.savedSearchesDetails.getByRole('button', { name: savedSearchName })).toBeVisible();
+    });
+
+    test('can load a saved search', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.saveSearch(`Load Test ${testRunId}`);
+
+      await flawSearchPage.page.reload();
+      await flawSearchPage.waitForResults();
+      await flawSearchPage.selectSavedSearch(`Load Test ${testRunId}`);
+
+      const button = flawSearchPage.savedSearchesDetails.getByRole('button', { name: `Load Test ${testRunId}` });
+      await expect(button).toHaveClass(/btn-secondary/);
+    });
+
+    test('can delete a saved search', async ({ flawSearchPage }) => {
+      const deleteSearchName = `Delete Test ${testRunId}`;
+      await flawSearchPage.addFacetWithSelect('Embargoed', 'false');
+      await flawSearchPage.saveSearch(deleteSearchName);
+
+      // Dismiss the "Search saved" toast notification to unblock saved searches section
+      const toast = flawSearchPage.page.locator('.alert').filter({ hasText: 'Search saved' });
+      const toastCloseButton = toast.locator('button').first();
+      await toastCloseButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => undefined);
+      if (await toastCloseButton.isVisible()) {
+        await toastCloseButton.click();
+        await toast.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => undefined);
+      }
+
+      await flawSearchPage.selectSavedSearch(deleteSearchName);
+      await flawSearchPage.deleteCurrentSavedSearch();
+      await expect(flawSearchPage.savedSearchesDetails.getByRole('button', { name: deleteSearchName })).not.toBeVisible();
+    });
+
+    test('can set a saved search as default', async ({ flawSearchPage }) => {
+      const defaultSearchName = `Default Test ${testRunId}`;
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.saveSearch(defaultSearchName);
+
+      // Dismiss the "Search saved" toast notification
+      const toast = flawSearchPage.page.locator('.alert').filter({ hasText: 'Search saved' });
+      const toastCloseButton = toast.locator('button').first();
+      await toastCloseButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => undefined);
+      if (await toastCloseButton.isVisible()) {
+        await toastCloseButton.click();
+        await toast.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => undefined);
+      }
+
+      await flawSearchPage.setDefaultSearch(defaultSearchName);
+
+      const button = flawSearchPage.savedSearchesDetails.getByRole('button', { name: defaultSearchName });
+      await expect(button.locator('i.bi-star-fill')).toBeVisible();
+    });
+
+    test('shows "No saved searches" when empty', async ({ page, flawSearchPage }) => {
+      await page.evaluate(() => {
+        localStorage.removeItem('SearchStore');
+      });
+      await page.reload();
+      await flawSearchPage.waitForResults();
+      await expect(flawSearchPage.noSavedSearchesText).toBeVisible();
+    });
+  });
+
+  test.describe('UI interactions', () => {
+    test('can expand/collapse Advanced Search section', async ({ flawSearchPage }) => {
+      await expect(flawSearchPage.advancedSearchDetails).toHaveAttribute('open');
+      await flawSearchPage.advancedSearchSummary.click();
+      await flawSearchPage.advancedSearchSummary.click();
+    });
+
+    test('can expand/collapse Saved Searches section', async ({ flawSearchPage }) => {
+      await expect(flawSearchPage.savedSearchesDetails).toHaveAttribute('open');
+      await flawSearchPage.savedSearchesSummary.click();
+      await flawSearchPage.savedSearchesSummary.click();
+    });
+
+    // TODO: Skip until OSIM fixes aria-labels - question mark icon has wrong aria-label "hide query filter"
+    test.skip('can hide and show query filter', async ({ flawSearchPage }) => {
+      await expect(flawSearchPage.queryFilterInput).toBeVisible();
+      await flawSearchPage.queryFilterHideButton.click();
+      await expect(flawSearchPage.queryFilterInput).not.toBeVisible();
+      await flawSearchPage.queryFilterHideButton.click();
+      await expect(flawSearchPage.queryFilterInput).toBeVisible();
+    });
+
+    test('can open query filter guide modal', async ({ flawSearchPage }) => {
+      // Click the second "hide query filter" button which is actually the guide icon (OSIM bug: wrong aria-label)
+      const guideButton = flawSearchPage.page.getByRole('button', { name: 'hide query filter' }).nth(1);
+      await guideButton.click();
+
+      const modalHeading = flawSearchPage.page.getByRole('heading', { name: 'Query Filter Guide' });
+      await expect(modalHeading).toBeVisible();
+
+      // Close modal and wait for it to disappear
+      await flawSearchPage.page.getByRole('button', { name: 'Close' }).first().click();
+      await expect(modalHeading).not.toBeVisible();
+    });
+  });
+
+  test.describe('search results', () => {
+    test('displays results after search', async ({ flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.search();
+      await expect(flawSearchPage.resultsTable).toBeVisible();
+    });
+
+    test('clicking on result navigates to flaw page', async ({ page, flawSearchPage }) => {
+      await flawSearchPage.addFacetWithSelect('CVE Source', 'REDHAT');
+      await flawSearchPage.search();
+      await flawSearchPage.resultRows.first().locator('td').first().click();
+      await expect(page).toHaveURL(/flaws\/\w+/);
+    });
+  });
+});


### PR DESCRIPTION
Add comprehensive test coverage for the Advanced Search page.
Changes
- Add `FlawSearchPage` page object with locators and interaction methods
- Add `flawSearchPage` fixture for test setup
- Add tests for facet-based search (title, impact, source, state, embargoed)
- Add tests for DjangoQL query filter operators (=, !=, ~, in, and, or)
- Add tests for sorting and saved searches
- Add tests for UI interactions and search results