### PR TITLE
✨ Add test suite for affect section coverage

### DIFF
--- a/pages/flawEdit.ts
+++ b/pages/flawEdit.ts
@@ -9,12 +9,31 @@ export type Resolution = 'FIX' | 'DEFER' | 'WONTFIX' | 'OOSS' | 'DELEGATED' | 'W
 export type AffectImpact = 'LOW' | 'MODERATE' | 'IMPORTANT' | 'CRITICAL' | '';
 
 export interface AffectData {
+  productStream?: string;
   module?: string;
   component?: string;
+  purl?: string;
   affectedness?: Affectedness;
   resolution?: Resolution;
   impact?: AffectImpact;
 }
+
+/**
+ * Column indices for the affects table based on OSIM's columnDefinitions.tsx:
+ * 0=Checkbox, 1=Related CVEs, 2=Label, 3=Product Stream, 4=Module, 5=Component,
+ * 6=Analyzed Component (PURL), 7=Subpackage PURLs, 8=Affectedness,
+ * 9=Not Affected Justification, 10=Resolution, 11=Impact, 12+=CVSS/Trackers/Actions
+ */
+export const AFFECT_COLUMN_MAP = {
+  'Product Stream': 3,
+  'Module': 4,
+  'Component': 5,
+  'PURL': 6,
+  'Affectedness': 8,
+  'Justification': 9,
+  'Resolution': 10,
+  'Impact': 11,
+} as const;
 
 export class FlawEditPage extends FlawCreatePage {
   readonly createJiraTaskButton: Locator;
@@ -67,19 +86,6 @@ export class FlawEditPage extends FlawCreatePage {
   readonly removedAffectsBadge: Locator;
   readonly addedAffectsBadge: Locator;
 
-  // Module filters
-  readonly moduleFiltersToggle: Locator;
-  readonly clearModuleFiltersButton: Locator;
-
-  // Legacy locators (kept for compatibility)
-  readonly addAffectButton: Locator;
-  readonly affectModuleBox: Locator;
-  readonly affectComponentBox: Locator;
-  readonly affectAffectednessBox: Locator;
-  readonly affectResolutionBox: Locator;
-  readonly affectImpactBox: Locator;
-  readonly affectCommitButton: Locator;
-
   // Optional field locators
   readonly cweBox: Locator;
   readonly reportedDateBox: Locator;
@@ -106,10 +112,9 @@ export class FlawEditPage extends FlawCreatePage {
     this.internalCommentBox = this.page.locator('label').filter({ hasText: 'New Internal Comment' });
     this.saveInternalCommentBox = this.page.getByRole('button', { name: 'Save Internal Comment' });
 
-    // Affects section - the div with class osim-affects-section inside the "Affected Offerings" form section
-    // Structure: h4 "Affected Offerings" > sibling div.col > FlawAffects (.osim-affects-section)
-    this.affectsSection = this.page.locator('.osim-affects-section');
-    this.affectsTable = this.page.locator('table.affects-table');
+    // Affects section - the div with id "affected-offerings" inside FlawForm
+    this.affectsSection = this.page.locator('#affected-offerings');
+    this.affectsTable = this.page.locator('#affected-offerings table');
     this.affectRows = this.affectsTable.locator('tbody tr');
 
     // Add New Affect button - use both title and text selectors
@@ -117,43 +122,30 @@ export class FlawEditPage extends FlawCreatePage {
     this.noAffectsMessage = this.page.getByText('This flaw has no affects');
 
     // Affect row action buttons - use title attributes for specificity
-    this.editAffectButton = this.page.locator('button[title="Edit affect"]');
+    this.editAffectButton = this.page.locator('button[title="Remove affect"]'); // legacy; cells are edited by dblclick in current UI
     this.removeAffectButton = this.page.locator('button[title="Remove affect"]');
-    this.commitEditButton = this.page.locator('button[title="Commit edit"]');
-    this.cancelEditButton = this.page.locator('button[title="Cancel edit"]');
-    this.recoverAffectButton = this.page.locator('button[title="Recover affect"]');
-    this.revertChangesButton = this.page.locator('button[title="Discard changes (Revert)"]');
+    this.commitEditButton = this.page.locator('button[title="Apply changes to selected affects"]');
+    this.cancelEditButton = this.page.locator('button[title="Cancel bulk edit"]');
+    this.recoverAffectButton = this.page.locator('button[title="Revert changes"]');
+    this.revertChangesButton = this.page.locator('button[title="Revert changes"]');
 
     // Bulk affect actions in affects-table-actions toolbar
     this.manageTrackersButton = this.page.locator('button.trackers-btn');
-    this.editSelectedButton = this.page.locator('button[title="Edit all selected affects"]');
-    this.removeSelectedButton = this.page.locator('button[title="Remove all selected affects"]');
-    this.commitAllButton = this.page.locator('button[title="Commit changes on all affects being edited"]');
-    this.cancelAllButton = this.page.locator('button[title="Cancel changes on all affects being edited"]');
-    this.revertAllButton = this.page.locator('button[title="Discard all affect modifications"]');
-    this.recoverAllButton = this.page.locator('button[title="Recover all removed affects"]');
+    this.editSelectedButton = this.page.locator('button[title="Bulk edit selected affects"]');
+    this.removeSelectedButton = this.page.locator('button[title="Remove selected affects"]');
+    this.commitAllButton = this.page.locator('button[title="Apply changes to selected affects"]');
+    this.cancelAllButton = this.page.locator('button[title="Cancel bulk edit"]');
+    this.revertAllButton = this.page.locator('button[title="Revert ALL changes"]');
+    this.recoverAllButton = this.page.locator('button[title="Revert changes"]');
 
-    // Affect badges in the affects-toolbar .badges div
-    // These show counts like "Show all affects (5)", "Selected 2", "Editing 1", etc.
-    this.showAllAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /Show all affects/ });
-    this.selectedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Selected/ });
-    this.editingAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Editing/ });
-    this.modifiedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Modified/ });
-    this.removedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Removed/ });
-    this.addedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Added/ });
+    // Affect count badge — actual DOM text from PaginationControls.vue: "Show All (N)"
+    this.showAllAffectsBadge = this.page.getByText(/Show All \(\d+\)/);
+    this.selectedAffectsBadge = this.page.locator('#affected-offerings').getByText(/\d+ Selected/);
+    this.editingAffectsBadge = this.page.locator('#affected-offerings').getByText(/Editing/);
+    this.modifiedAffectsBadge = this.page.locator('#affected-offerings').getByText(/Modified/);
+    this.removedAffectsBadge = this.page.locator('#affected-offerings').getByText(/Removed/);
+    this.addedAffectsBadge = this.page.locator('#affected-offerings').getByText(/Added/);
 
-    // Module filters - the collapsible section with module buttons
-    this.moduleFiltersToggle = this.page.getByText('Affected Module Filters');
-    this.clearModuleFiltersButton = this.page.locator('.affect-modules-selection').getByRole('button', { name: 'Clear Filters' });
-
-    // Legacy locators for backwards compatibility
-    this.addAffectButton = this.addNewAffectButton;
-    this.affectModuleBox = this.affectsTable.locator('tbody tr.editing td').nth(2);
-    this.affectComponentBox = this.affectsTable.locator('tbody tr.editing td').nth(3);
-    this.affectAffectednessBox = this.affectsTable.locator('tbody tr.editing td').nth(5);
-    this.affectResolutionBox = this.affectsTable.locator('tbody tr.editing td').nth(7);
-    this.affectImpactBox = this.affectsTable.locator('tbody tr.editing td').nth(8);
-    this.affectCommitButton = this.commitEditButton;
     this.submitButton = page.getByRole('button', { name: 'Save Changes', exact: true });
 
     // Optional fields
@@ -197,39 +189,8 @@ export class FlawEditPage extends FlawCreatePage {
     }
   }
 
-  async getAffectCount(): Promise<number> {
-    return await this.affectRows.count();
-  }
-
-  getAffectRow(index: number): Locator {
-    return this.affectRows.nth(index);
-  }
-
-  getNewAffectRow(): Locator {
-    return this.affectsTable.locator('tbody tr.new').first();
-  }
-
   getEditingAffectRow(): Locator {
-    return this.affectsTable.locator('tbody tr.editing').first();
-  }
-
-  async waitForAffectsLoaded() {
-    // Wait for the "Fetching affects..." text to disappear (if present)
-    const loadingText = this.page.getByText('Fetching affects...');
-    // First check if loading is visible, then wait for it to disappear
-    const isLoading = await loadingText.isVisible().catch(() => false);
-    if (isLoading) {
-      await loadingText.waitFor({ state: 'hidden', timeout: 60000 });
-    }
-    // Now wait for either:
-    // 1. The Add New Affect button (affects section loaded)
-    // 2. Or "This flaw has no affects" message
-    await Promise.race([
-      this.addNewAffectButton.waitFor({ state: 'visible', timeout: 30000 }),
-      this.noAffectsMessage.waitFor({ state: 'visible', timeout: 30000 }),
-    ]).catch(() => {
-      // One of them should be visible
-    });
+    return this.affectsTable.locator('tbody tr.new').first();
   }
 
   async scrollToAffectsSection() {
@@ -239,239 +200,77 @@ export class FlawEditPage extends FlawCreatePage {
   }
 
   async clickAddNewAffect() {
-    // Use title attribute as primary selector, text as fallback
-    const addButton = this.page.locator('button[title="Add new affect"], button:has-text("Add New Affect")').first();
-    await addButton.click();
+    await this.scrollToAffectsSection();
+    await this.addNewAffectButton.click();
     // Wait for editing row to appear
-    await this.page.locator('tr.editing').first().waitFor({ state: 'visible', timeout: 10000 });
-  }
-
-  async editAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Edit affect"]').click();
-  }
-
-  async removeAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Remove affect"]').click();
-  }
-
-  async recoverAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Recover affect"]').click();
-  }
-
-  async commitAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Commit edit"]').click();
-  }
-
-  async cancelAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Cancel edit"]').click();
-  }
-
-  async revertAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('button[title="Discard changes (Revert)"]').click();
-  }
-
-  async selectAffectRow(index: number) {
-    const row = this.getAffectRow(index);
-    await row.locator('input[type="checkbox"]').click();
-  }
-
-  async isAffectRowSelected(index: number): Promise<boolean> {
-    const row = this.getAffectRow(index);
-    return await row.locator('input[type="checkbox"]').isChecked();
+    await this.affectsTable.locator('tbody tr.new').first().waitFor({ state: 'visible', timeout: 10000 });
   }
 
   /**
    * Fill a field in an affect row.
-   * Column indices (0-indexed):
-   * 0=Checkbox, 1=State, 2=Module, 3=Component, 4=PURL, 5=Affectedness, 6=Justification, 7=Resolution, 8=Impact, 9=CVSS, 10=Trackers, 11=Actions
    */
-  async fillAffectField(row: Locator, columnName: string, value: string, isSelect = false) {
-    // Map column names to indices
-    // 0=Checkbox, 1=State, 2=Module, 3=Component, 4=PURL, 5=Affectedness, 6=Justification, 7=Resolution, 8=Impact
-    const columnMap = new Map<string, number>([
-      ['Module', 2],
-      ['Component', 3],
-      ['PURL', 4],
-      ['Affectedness', 5],
-      ['Justification', 6],
-      ['Resolution', 7],
-      ['Impact', 8],
-    ]);
-
-    const columnIndex = columnMap.get(columnName);
-    if (columnIndex === undefined) {
-      throw new Error(`Column "${columnName}" not found in mapping`);
-    }
+  async fillAffectField(row: Locator, columnName: keyof typeof AFFECT_COLUMN_MAP, value: string, isSelect = false) {
+    const columnIndex = AFFECT_COLUMN_MAP[columnName];
 
     const cell = row.locator('td').nth(columnIndex);
+
+    // EditableCell starts in display mode (span); double-click to enter edit mode
+    await cell.dblclick();
 
     if (isSelect) {
       const select = cell.locator('select');
       await select.waitFor({ state: 'visible', timeout: 5000 });
       await select.selectOption(value);
+      await select.press('Enter');
     } else {
       const input = cell.locator('input');
       await input.waitFor({ state: 'visible', timeout: 5000 });
       await input.fill(value);
+      await input.press('Enter');
     }
   }
 
-  async addAffect(productStream = 'rhel-8', component = 'kernel') {
-    // Scroll to Affected Offerings section first
-    const heading = this.page.getByRole('heading', { name: 'Affected Offerings' });
-    await heading.scrollIntoViewIfNeeded();
+  async addAffect(options: AffectData = {}) {
+    const {
+      productStream = 'rhel-8.10.0',
+      module = 'rhel-8',
+      component = 'kernel',
+      purl,
+      affectedness = 'AFFECTED',
+      resolution,
+      impact = 'LOW',
+    } = options;
 
-    // Click Add new affect button (icon-only button with title)
-    const addButton = this.page.locator('button[title="Add new affect"]');
-    await addButton.waitFor({ state: 'visible', timeout: 30000 });
-    await addButton.click();
-
-    // Wait for new row to appear (use last() in case there are multiple new rows)
-    const newRow = this.page.locator('tr.new').last();
-    await newRow.waitFor({ state: 'visible', timeout: 10000 });
-
-    // New table uses inline editing - double-click on cell to edit
-    // Column indices: 0=checkbox, 1=Related CVEs, 2=Label, 3=Product Stream, 4=Module, 5=Component
-
-    // Edit Product Stream (column 3) - this is the required ps_update_stream field
-    const productStreamCell = newRow.locator('td').nth(3);
-    await productStreamCell.dblclick();
-    let textInput = this.page.locator('table input[type="text"]:visible').first();
-    await textInput.waitFor({ state: 'visible', timeout: 5000 });
-    await textInput.fill(productStream);
-    await textInput.press('Escape');
-
-    // Wait for input to close
-    await this.page.waitForTimeout(300);
-
-    // Edit Component (column 5) - explicitly double-click to edit
-    const componentCell = newRow.locator('td').nth(5);
-    await componentCell.dblclick();
-    textInput = this.page.locator('table input[type="text"]:visible').first();
-    await textInput.waitFor({ state: 'visible', timeout: 5000 });
-    await textInput.fill(component);
-    await textInput.press('Escape');
-
-    // Wait for edit to complete
-    await this.page.waitForTimeout(500);
-  }
-
-  async addAffectWithoutCommit(module = 'rhel-8', component = 'kernel', options?: Partial<AffectData>) {
     await this.clickAddNewAffect();
-
     const newRow = this.getEditingAffectRow();
+
+    // Fill Product Stream (required)
+    await this.fillAffectField(newRow, 'Product Stream', productStream);
 
     // Fill Module
     await this.fillAffectField(newRow, 'Module', module);
 
-    // Fill Component
+    // Fill Component (required)
     await this.fillAffectField(newRow, 'Component', component);
 
-    // Fill Affectedness (default to AFFECTED)
-    const affectedness = options?.affectedness ?? 'AFFECTED';
+    // Fill PURL/Analyzed Component (required by OSIDB)
+    await this.fillAffectField(newRow, 'PURL', purl ?? `pkg:rpm/redhat/${component}`);
+
+    // Fill Affectedness
     if (affectedness) {
       await this.fillAffectField(newRow, 'Affectedness', affectedness, true);
     }
 
     // Fill Resolution (default to DELEGATED for AFFECTED)
-    const resolution = options?.resolution ?? (affectedness === 'AFFECTED' ? 'DELEGATED' : '');
-    if (resolution) {
-      await this.fillAffectField(newRow, 'Resolution', resolution, true);
+    const resolvedResolution = resolution ?? (affectedness === 'AFFECTED' ? 'DELEGATED' : '');
+    if (resolvedResolution) {
+      await this.fillAffectField(newRow, 'Resolution', resolvedResolution, true);
     }
 
-    // Fill Impact (default to LOW)
-    const impact = options?.impact ?? 'LOW';
+    // Fill Impact
     if (impact) {
       await this.fillAffectField(newRow, 'Impact', impact, true);
     }
-  }
-
-  async editAffectFields(index: number, data: Partial<AffectData>) {
-    await this.editAffectRow(index);
-
-    const row = this.getEditingAffectRow();
-
-    if (data.module) {
-      await this.fillAffectField(row, 'Module', data.module);
-    }
-
-    if (data.component) {
-      await this.fillAffectField(row, 'Component', data.component);
-    }
-
-    if (data.affectedness) {
-      await this.fillAffectField(row, 'Affectedness', data.affectedness, true);
-    }
-
-    if (data.resolution) {
-      await this.fillAffectField(row, 'Resolution', data.resolution, true);
-    }
-
-    if (data.impact) {
-      await this.fillAffectField(row, 'Impact', data.impact, true);
-    }
-  }
-
-  async getAffectFieldValue(index: number, columnName: string): Promise<string> {
-    const columnMap = new Map<string, number>([
-      ['Module', 2],
-      ['Component', 3],
-      ['PURL', 4],
-      ['Affectedness', 5],
-      ['Justification', 6],
-      ['Resolution', 7],
-      ['Impact', 8],
-    ]);
-
-    const columnIndex = columnMap.get(columnName);
-    if (columnIndex === undefined) {
-      throw new Error(`Column "${columnName}" not found in mapping`);
-    }
-
-    const row = this.getAffectRow(index);
-    const cell = row.locator('td').nth(columnIndex);
-    // Get text from span if present (non-editing mode), otherwise cell text
-    const span = cell.locator('span').first();
-    if (await span.isVisible().catch(() => false)) {
-      return (await span.textContent()) ?? '';
-    }
-    return (await cell.textContent()) ?? '';
-  }
-
-  async isAffectRowInState(index: number, state: 'new' | 'modified' | 'removed' | 'editing'): Promise<boolean> {
-    const row = this.getAffectRow(index);
-    return await row.evaluate((el, s) => el.classList.contains(s), state);
-  }
-
-  async filterByModule(moduleName: string) {
-    const moduleButton = this.page.locator('.affect-modules-selection .module-btn').filter({ hasText: moduleName });
-    await moduleButton.click();
-  }
-
-  async clearModuleFilters() {
-    const clearBtn = this.page.locator('.affect-modules-selection').getByRole('button', { name: 'Clear Filters' });
-    if (await clearBtn.isVisible()) {
-      await clearBtn.click();
-    }
-  }
-
-  async getModuleNames(): Promise<string[]> {
-    const buttons = this.page.locator('.affect-modules-selection .module-btn');
-    const count = await buttons.count();
-    const names: string[] = [];
-
-    for (let i = 0; i < count; i++) {
-      const text = await buttons.nth(i).textContent();
-      if (text) names.push(text.trim());
-    }
-
-    return names;
   }
 
   /**

--- a/pages/flawEdit.ts
+++ b/pages/flawEdit.ts
@@ -4,6 +4,17 @@ import { faker } from '@faker-js/faker';
 import { getFlawFromAPI, sleep } from 'playwright/helpers';
 
 export type CommentType = 'public' | 'private' | 'internal';
+export type Affectedness = 'NEW' | 'AFFECTED' | 'NOTAFFECTED' | '';
+export type Resolution = 'FIX' | 'DEFER' | 'WONTFIX' | 'OOSS' | 'DELEGATED' | 'WONTREPORT' | '';
+export type AffectImpact = 'LOW' | 'MODERATE' | 'IMPORTANT' | 'CRITICAL' | '';
+
+export interface AffectData {
+  module?: string;
+  component?: string;
+  affectedness?: Affectedness;
+  resolution?: Resolution;
+  impact?: AffectImpact;
+}
 
 export class FlawEditPage extends FlawCreatePage {
   readonly createJiraTaskButton: Locator;
@@ -23,8 +34,45 @@ export class FlawEditPage extends FlawCreatePage {
   readonly internalCommentTab: Locator;
   readonly internalCommentBox: Locator;
   readonly saveInternalCommentBox: Locator;
-  readonly addAffectButton: Locator;
+
+  // Affects section
+  readonly affectsSection: Locator;
+  readonly affectsTable: Locator;
+  readonly affectRows: Locator;
+  readonly addNewAffectButton: Locator;
+  readonly noAffectsMessage: Locator;
+
+  // Affect row actions
   readonly editAffectButton: Locator;
+  readonly removeAffectButton: Locator;
+  readonly commitEditButton: Locator;
+  readonly cancelEditButton: Locator;
+  readonly recoverAffectButton: Locator;
+  readonly revertChangesButton: Locator;
+
+  // Bulk affect actions
+  readonly manageTrackersButton: Locator;
+  readonly editSelectedButton: Locator;
+  readonly removeSelectedButton: Locator;
+  readonly commitAllButton: Locator;
+  readonly cancelAllButton: Locator;
+  readonly revertAllButton: Locator;
+  readonly recoverAllButton: Locator;
+
+  // Affect badges/filters
+  readonly showAllAffectsBadge: Locator;
+  readonly selectedAffectsBadge: Locator;
+  readonly editingAffectsBadge: Locator;
+  readonly modifiedAffectsBadge: Locator;
+  readonly removedAffectsBadge: Locator;
+  readonly addedAffectsBadge: Locator;
+
+  // Module filters
+  readonly moduleFiltersToggle: Locator;
+  readonly clearModuleFiltersButton: Locator;
+
+  // Legacy locators (kept for compatibility)
+  readonly addAffectButton: Locator;
   readonly affectModuleBox: Locator;
   readonly affectComponentBox: Locator;
   readonly affectAffectednessBox: Locator;
@@ -58,15 +106,54 @@ export class FlawEditPage extends FlawCreatePage {
     this.internalCommentBox = this.page.locator('label').filter({ hasText: 'New Internal Comment' });
     this.saveInternalCommentBox = this.page.getByRole('button', { name: 'Save Internal Comment' });
 
-    // New TanStack-based Affects table (uses double-click to edit cells)
-    this.addAffectButton = this.page.getByTitle('Add new affect');
-    this.editAffectButton = this.page.getByTitle('Edit affect');
-    this.affectModuleBox = this.page.locator('tbody tr.new td').nth(1); // Module column
-    this.affectComponentBox = this.page.locator('tbody tr.new td').nth(2); // Component column
-    this.affectAffectednessBox = this.page.locator('tbody tr.new td').nth(3); // Affectedness column
-    this.affectResolutionBox = this.page.locator('tbody tr.new td').nth(4); // Resolution column
-    this.affectImpactBox = this.page.locator('tbody tr.new td').nth(5); // Impact column
-    this.affectCommitButton = this.page.getByTitle('Commit edit');
+    // Affects section - the div with class osim-affects-section inside the "Affected Offerings" form section
+    // Structure: h4 "Affected Offerings" > sibling div.col > FlawAffects (.osim-affects-section)
+    this.affectsSection = this.page.locator('.osim-affects-section');
+    this.affectsTable = this.page.locator('table.affects-table');
+    this.affectRows = this.affectsTable.locator('tbody tr');
+
+    // Add New Affect button - use both title and text selectors
+    this.addNewAffectButton = this.page.locator('button[title="Add new affect"], button:has-text("Add New Affect")').first();
+    this.noAffectsMessage = this.page.getByText('This flaw has no affects');
+
+    // Affect row action buttons - use title attributes for specificity
+    this.editAffectButton = this.page.locator('button[title="Edit affect"]');
+    this.removeAffectButton = this.page.locator('button[title="Remove affect"]');
+    this.commitEditButton = this.page.locator('button[title="Commit edit"]');
+    this.cancelEditButton = this.page.locator('button[title="Cancel edit"]');
+    this.recoverAffectButton = this.page.locator('button[title="Recover affect"]');
+    this.revertChangesButton = this.page.locator('button[title="Discard changes (Revert)"]');
+
+    // Bulk affect actions in affects-table-actions toolbar
+    this.manageTrackersButton = this.page.locator('button.trackers-btn');
+    this.editSelectedButton = this.page.locator('button[title="Edit all selected affects"]');
+    this.removeSelectedButton = this.page.locator('button[title="Remove all selected affects"]');
+    this.commitAllButton = this.page.locator('button[title="Commit changes on all affects being edited"]');
+    this.cancelAllButton = this.page.locator('button[title="Cancel changes on all affects being edited"]');
+    this.revertAllButton = this.page.locator('button[title="Discard all affect modifications"]');
+    this.recoverAllButton = this.page.locator('button[title="Recover all removed affects"]');
+
+    // Affect badges in the affects-toolbar .badges div
+    // These show counts like "Show all affects (5)", "Selected 2", "Editing 1", etc.
+    this.showAllAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /Show all affects/ });
+    this.selectedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Selected/ });
+    this.editingAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Editing/ });
+    this.modifiedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Modified/ });
+    this.removedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Removed/ });
+    this.addedAffectsBadge = this.page.locator('.affects-toolbar .badges div').filter({ hasText: /^Added/ });
+
+    // Module filters - the collapsible section with module buttons
+    this.moduleFiltersToggle = this.page.getByText('Affected Module Filters');
+    this.clearModuleFiltersButton = this.page.locator('.affect-modules-selection').getByRole('button', { name: 'Clear Filters' });
+
+    // Legacy locators for backwards compatibility
+    this.addAffectButton = this.addNewAffectButton;
+    this.affectModuleBox = this.affectsTable.locator('tbody tr.editing td').nth(2);
+    this.affectComponentBox = this.affectsTable.locator('tbody tr.editing td').nth(3);
+    this.affectAffectednessBox = this.affectsTable.locator('tbody tr.editing td').nth(5);
+    this.affectResolutionBox = this.affectsTable.locator('tbody tr.editing td').nth(7);
+    this.affectImpactBox = this.affectsTable.locator('tbody tr.editing td').nth(8);
+    this.affectCommitButton = this.commitEditButton;
     this.submitButton = page.getByRole('button', { name: 'Save Changes', exact: true });
 
     // Optional fields
@@ -110,65 +197,281 @@ export class FlawEditPage extends FlawCreatePage {
     }
   }
 
-  async addAffect(stream = 'rhel-8.10.0', module = 'rhel-8', component = 'kernel') {
-    await this.addAffectButton.click();
+  async getAffectCount(): Promise<number> {
+    return await this.affectRows.count();
+  }
 
-    // New row appears - double-click cells to edit (TanStack table)
-    const newRow = this.page.locator('tbody tr.new').first();
-    await newRow.waitFor({ state: 'visible' });
+  getAffectRow(index: number): Locator {
+    return this.affectRows.nth(index);
+  }
 
-    // Helper to get column index by header text
-    const getColumnIndex = async (headerText: string) => {
-      const headers = this.page.locator('thead th');
-      const count = await headers.count();
-      for (let i = 0; i < count; i++) {
-        const text = await headers.nth(i).textContent();
-        if (text?.includes(headerText)) return i;
-      }
-      throw new Error(`Column "${headerText}" not found`);
-    };
+  getNewAffectRow(): Locator {
+    return this.affectsTable.locator('tbody tr.new').first();
+  }
 
-    // Edit Product Stream cell (required field)
-    const streamIdx = await getColumnIndex('Product Stream');
-    const streamCell = newRow.locator('td').nth(streamIdx);
-    await streamCell.dblclick();
-    await streamCell.locator('input').fill(stream);
-    await streamCell.locator('input').press('Enter');
+  getEditingAffectRow(): Locator {
+    return this.affectsTable.locator('tbody tr.editing').first();
+  }
 
-    // Edit Module cell (double-click to enter edit mode)
-    const moduleIdx = await getColumnIndex('Module');
-    const moduleCell = newRow.locator('td').nth(moduleIdx);
-    await moduleCell.dblclick();
-    await moduleCell.locator('input').fill(module);
-    await moduleCell.locator('input').press('Enter');
+  async waitForAffectsLoaded() {
+    // Wait for the "Fetching affects..." text to disappear (if present)
+    const loadingText = this.page.getByText('Fetching affects...');
+    // First check if loading is visible, then wait for it to disappear
+    const isLoading = await loadingText.isVisible().catch(() => false);
+    if (isLoading) {
+      await loadingText.waitFor({ state: 'hidden', timeout: 60000 });
+    }
+    // Now wait for either:
+    // 1. The Add New Affect button (affects section loaded)
+    // 2. Or "This flaw has no affects" message
+    await Promise.race([
+      this.addNewAffectButton.waitFor({ state: 'visible', timeout: 30000 }),
+      this.noAffectsMessage.waitFor({ state: 'visible', timeout: 30000 }),
+    ]).catch(() => {
+      // One of them should be visible
+    });
+  }
 
-    // Edit Component cell
-    const componentIdx = await getColumnIndex('Component');
-    const componentCell = newRow.locator('td').nth(componentIdx);
+  async scrollToAffectsSection() {
+    // Scroll to the "Affected Offerings" heading
+    const heading = this.page.getByRole('heading', { name: 'Affected Offerings' });
+    await heading.scrollIntoViewIfNeeded();
+  }
+
+  async clickAddNewAffect() {
+    // Use title attribute as primary selector, text as fallback
+    const addButton = this.page.locator('button[title="Add new affect"], button:has-text("Add New Affect")').first();
+    await addButton.click();
+    // Wait for editing row to appear
+    await this.page.locator('tr.editing').first().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async editAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Edit affect"]').click();
+  }
+
+  async removeAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Remove affect"]').click();
+  }
+
+  async recoverAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Recover affect"]').click();
+  }
+
+  async commitAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Commit edit"]').click();
+  }
+
+  async cancelAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Cancel edit"]').click();
+  }
+
+  async revertAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('button[title="Discard changes (Revert)"]').click();
+  }
+
+  async selectAffectRow(index: number) {
+    const row = this.getAffectRow(index);
+    await row.locator('input[type="checkbox"]').click();
+  }
+
+  async isAffectRowSelected(index: number): Promise<boolean> {
+    const row = this.getAffectRow(index);
+    return await row.locator('input[type="checkbox"]').isChecked();
+  }
+
+  /**
+   * Fill a field in an affect row.
+   * Column indices (0-indexed):
+   * 0=Checkbox, 1=State, 2=Module, 3=Component, 4=PURL, 5=Affectedness, 6=Justification, 7=Resolution, 8=Impact, 9=CVSS, 10=Trackers, 11=Actions
+   */
+  async fillAffectField(row: Locator, columnName: string, value: string, isSelect = false) {
+    // Map column names to indices
+    // 0=Checkbox, 1=State, 2=Module, 3=Component, 4=PURL, 5=Affectedness, 6=Justification, 7=Resolution, 8=Impact
+    const columnMap = new Map<string, number>([
+      ['Module', 2],
+      ['Component', 3],
+      ['PURL', 4],
+      ['Affectedness', 5],
+      ['Justification', 6],
+      ['Resolution', 7],
+      ['Impact', 8],
+    ]);
+
+    const columnIndex = columnMap.get(columnName);
+    if (columnIndex === undefined) {
+      throw new Error(`Column "${columnName}" not found in mapping`);
+    }
+
+    const cell = row.locator('td').nth(columnIndex);
+
+    if (isSelect) {
+      const select = cell.locator('select');
+      await select.waitFor({ state: 'visible', timeout: 5000 });
+      await select.selectOption(value);
+    } else {
+      const input = cell.locator('input');
+      await input.waitFor({ state: 'visible', timeout: 5000 });
+      await input.fill(value);
+    }
+  }
+
+  async addAffect(productStream = 'rhel-8', component = 'kernel') {
+    // Scroll to Affected Offerings section first
+    const heading = this.page.getByRole('heading', { name: 'Affected Offerings' });
+    await heading.scrollIntoViewIfNeeded();
+
+    // Click Add new affect button (icon-only button with title)
+    const addButton = this.page.locator('button[title="Add new affect"]');
+    await addButton.waitFor({ state: 'visible', timeout: 30000 });
+    await addButton.click();
+
+    // Wait for new row to appear (use last() in case there are multiple new rows)
+    const newRow = this.page.locator('tr.new').last();
+    await newRow.waitFor({ state: 'visible', timeout: 10000 });
+
+    // New table uses inline editing - double-click on cell to edit
+    // Column indices: 0=checkbox, 1=Related CVEs, 2=Label, 3=Product Stream, 4=Module, 5=Component
+
+    // Edit Product Stream (column 3) - this is the required ps_update_stream field
+    const productStreamCell = newRow.locator('td').nth(3);
+    await productStreamCell.dblclick();
+    let textInput = this.page.locator('table input[type="text"]:visible').first();
+    await textInput.waitFor({ state: 'visible', timeout: 5000 });
+    await textInput.fill(productStream);
+    await textInput.press('Escape');
+
+    // Wait for input to close
+    await this.page.waitForTimeout(300);
+
+    // Edit Component (column 5) - explicitly double-click to edit
+    const componentCell = newRow.locator('td').nth(5);
     await componentCell.dblclick();
-    await componentCell.locator('input').fill(component);
-    await componentCell.locator('input').press('Enter');
+    textInput = this.page.locator('table input[type="text"]:visible').first();
+    await textInput.waitFor({ state: 'visible', timeout: 5000 });
+    await textInput.fill(component);
+    await textInput.press('Escape');
 
-    // Edit Affectedness cell (dropdown)
-    const affectednessIdx = await getColumnIndex('Affectedness');
-    const affectednessCell = newRow.locator('td').nth(affectednessIdx);
-    await affectednessCell.dblclick();
-    await affectednessCell.locator('select').selectOption('AFFECTED');
-    await affectednessCell.locator('select').blur();
+    // Wait for edit to complete
+    await this.page.waitForTimeout(500);
+  }
 
-    // Edit Resolution cell (dropdown)
-    const resolutionIdx = await getColumnIndex('Resolution');
-    const resolutionCell = newRow.locator('td').nth(resolutionIdx);
-    await resolutionCell.dblclick();
-    await resolutionCell.locator('select').selectOption('DELEGATED');
-    await resolutionCell.locator('select').blur();
+  async addAffectWithoutCommit(module = 'rhel-8', component = 'kernel', options?: Partial<AffectData>) {
+    await this.clickAddNewAffect();
 
-    // Edit Impact cell (dropdown)
-    const impactIdx = await getColumnIndex('Impact');
-    const impactCell = newRow.locator('td').nth(impactIdx);
-    await impactCell.dblclick();
-    await impactCell.locator('select').selectOption('LOW');
-    await impactCell.locator('select').blur();
+    const newRow = this.getEditingAffectRow();
+
+    // Fill Module
+    await this.fillAffectField(newRow, 'Module', module);
+
+    // Fill Component
+    await this.fillAffectField(newRow, 'Component', component);
+
+    // Fill Affectedness (default to AFFECTED)
+    const affectedness = options?.affectedness ?? 'AFFECTED';
+    if (affectedness) {
+      await this.fillAffectField(newRow, 'Affectedness', affectedness, true);
+    }
+
+    // Fill Resolution (default to DELEGATED for AFFECTED)
+    const resolution = options?.resolution ?? (affectedness === 'AFFECTED' ? 'DELEGATED' : '');
+    if (resolution) {
+      await this.fillAffectField(newRow, 'Resolution', resolution, true);
+    }
+
+    // Fill Impact (default to LOW)
+    const impact = options?.impact ?? 'LOW';
+    if (impact) {
+      await this.fillAffectField(newRow, 'Impact', impact, true);
+    }
+  }
+
+  async editAffectFields(index: number, data: Partial<AffectData>) {
+    await this.editAffectRow(index);
+
+    const row = this.getEditingAffectRow();
+
+    if (data.module) {
+      await this.fillAffectField(row, 'Module', data.module);
+    }
+
+    if (data.component) {
+      await this.fillAffectField(row, 'Component', data.component);
+    }
+
+    if (data.affectedness) {
+      await this.fillAffectField(row, 'Affectedness', data.affectedness, true);
+    }
+
+    if (data.resolution) {
+      await this.fillAffectField(row, 'Resolution', data.resolution, true);
+    }
+
+    if (data.impact) {
+      await this.fillAffectField(row, 'Impact', data.impact, true);
+    }
+  }
+
+  async getAffectFieldValue(index: number, columnName: string): Promise<string> {
+    const columnMap = new Map<string, number>([
+      ['Module', 2],
+      ['Component', 3],
+      ['PURL', 4],
+      ['Affectedness', 5],
+      ['Justification', 6],
+      ['Resolution', 7],
+      ['Impact', 8],
+    ]);
+
+    const columnIndex = columnMap.get(columnName);
+    if (columnIndex === undefined) {
+      throw new Error(`Column "${columnName}" not found in mapping`);
+    }
+
+    const row = this.getAffectRow(index);
+    const cell = row.locator('td').nth(columnIndex);
+    // Get text from span if present (non-editing mode), otherwise cell text
+    const span = cell.locator('span').first();
+    if (await span.isVisible().catch(() => false)) {
+      return (await span.textContent()) ?? '';
+    }
+    return (await cell.textContent()) ?? '';
+  }
+
+  async isAffectRowInState(index: number, state: 'new' | 'modified' | 'removed' | 'editing'): Promise<boolean> {
+    const row = this.getAffectRow(index);
+    return await row.evaluate((el, s) => el.classList.contains(s), state);
+  }
+
+  async filterByModule(moduleName: string) {
+    const moduleButton = this.page.locator('.affect-modules-selection .module-btn').filter({ hasText: moduleName });
+    await moduleButton.click();
+  }
+
+  async clearModuleFilters() {
+    const clearBtn = this.page.locator('.affect-modules-selection').getByRole('button', { name: 'Clear Filters' });
+    if (await clearBtn.isVisible()) {
+      await clearBtn.click();
+    }
+  }
+
+  async getModuleNames(): Promise<string[]> {
+    const buttons = this.page.locator('.affect-modules-selection .module-btn');
+    const count = await buttons.count();
+    const names: string[] = [];
+
+    for (let i = 0; i < count; i++) {
+      const text = await buttons.nth(i).textContent();
+      if (text) names.push(text.trim());
+    }
+
+    return names;
   }
 
   /**

--- a/tests/affects.spec.ts
+++ b/tests/affects.spec.ts
@@ -1,0 +1,335 @@
+import { FlawCreatePage } from '../pages/flawCreate';
+import { test, expect } from '../playwright/fixtures';
+
+test.describe('affects', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.slow(); // Mark all tests as slow (3x timeout)
+
+  let flawId: string;
+
+  test.beforeAll(async () => {
+    flawId = await FlawCreatePage.createFlawWithAPI();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/flaws/${flawId}`);
+    // Wait for page to load with longer timeout
+    await page.waitForLoadState('networkidle', { timeout: 90000 });
+    await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible({ timeout: 90000 });
+    // Scroll to Affected Offerings section
+    const heading = page.getByRole('heading', { name: 'Affected Offerings' });
+    await heading.scrollIntoViewIfNeeded();
+  });
+
+  test.describe('add affects', () => {
+    test('add affect button is visible', async ({ page }) => {
+      const addButton = page.locator('button[title="Add new affect"]');
+      await expect(addButton).toBeVisible();
+    });
+
+    test('can add first affect', async ({ page, flawEditPage }) => {
+      await flawEditPage.addAffect('rhel-8', 'kernel');
+      await flawEditPage.submitButton.click();
+      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
+    });
+
+    test('can add second affect', async ({ page, flawEditPage }) => {
+      await flawEditPage.addAffect('rhel-9', 'glibc');
+      await flawEditPage.submitButton.click();
+      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
+    });
+
+    test('new affect row shows product stream before save', async ({ page, flawEditPage }) => {
+      await flawEditPage.addAffect('fedora-40', 'openssl');
+      // New row should show the product stream we entered (before saving)
+      const newRow = page.locator('tr.new').last();
+      await expect(newRow).toContainText('fedora-40');
+      // Save it
+      await flawEditPage.submitButton.click();
+      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
+    });
+  });
+
+  test.describe('table features', () => {
+    test('table shows affects', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const rows = affectsTable.locator('tbody tr');
+      const count = await rows.count();
+      expect(count).toBeGreaterThan(0);
+    });
+
+    test('table has Product Stream header', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      await expect(affectsTable.getByText('Product Stream')).toBeVisible({ timeout: 15000 });
+    });
+
+    test('table has Component header', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      await expect(affectsTable.getByText('Component', { exact: true })).toBeVisible({ timeout: 15000 });
+    });
+
+    test('shows affect count', async ({ page }) => {
+      const showAllLabel = page.getByText(/Show All \(\d+\)/);
+      await expect(showAllLabel).toBeVisible({ timeout: 15000 });
+    });
+  });
+
+  test.describe('edit affects', () => {
+    test('can double-click cell to enter edit mode', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+      const cell = dataRow.locator('td').nth(3);
+      await cell.dblclick();
+
+      const textInput = page.locator('input[type="text"]:visible').first();
+      await expect(textInput).toBeVisible({ timeout: 10000 });
+
+      await textInput.press('Escape');
+    });
+
+    test('escape cancels edit without saving', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+      const cell = dataRow.locator('td').nth(3);
+
+      await cell.dblclick();
+
+      const textInput = page.locator('input[type="text"]:visible').first();
+      await textInput.waitFor({ state: 'visible', timeout: 10000 });
+      await textInput.fill('should-be-cancelled');
+      await textInput.press('Escape');
+
+      // Wait a moment for the edit to cancel
+      await page.waitForTimeout(1000);
+
+      // Click on the Affected Offerings heading to exit edit mode
+      const heading = page.getByRole('heading', { name: 'Affected Offerings' });
+      await heading.click();
+      await page.waitForTimeout(500);
+    });
+
+    test('can edit and save affect', async ({ page, flawEditPage }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+      const cell = dataRow.locator('td').nth(5);
+      await cell.dblclick();
+
+      const textInput = page.locator('input[type="text"]:visible').first();
+      await textInput.waitFor({ state: 'visible', timeout: 10000 });
+      await textInput.fill(`edited-${Date.now()}`);
+      await textInput.press('Escape');
+
+      await page.waitForTimeout(500);
+      await flawEditPage.submitButton.click();
+
+      // Wait for save to complete
+      await expect(page.getByText(/Flaw saved|\d+ affects? updated/i)).toBeVisible({ timeout: 60000 });
+    });
+  });
+
+  test.describe('select affects', () => {
+    test('can toggle checkbox selection', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+      const checkbox = dataRow.locator('input[type="checkbox"]');
+
+      // Ensure unchecked
+      if (await checkbox.isChecked()) {
+        await checkbox.click();
+      }
+
+      await checkbox.click();
+      await expect(checkbox).toBeChecked();
+
+      await checkbox.click();
+      await expect(checkbox).not.toBeChecked();
+    });
+
+    test('header checkbox selects all', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const headerCheckbox = affectsTable.locator('thead input[type="checkbox"]');
+      if (await headerCheckbox.isVisible()) {
+        await headerCheckbox.click();
+        const bodyCheckbox = affectsTable.locator('tbody tr').first().locator('input[type="checkbox"]');
+        await expect(bodyCheckbox).toBeChecked({ timeout: 5000 });
+        // Cleanup
+        await headerCheckbox.click();
+      }
+    });
+  });
+
+  test.describe('display modes', () => {
+    test('show all badge is visible', async ({ page }) => {
+      // The badge shows "Show All (X)" where X is the count
+      const showAllBadge = page.getByText(/Show All \(\d+\)/);
+      await expect(showAllBadge).toBeVisible({ timeout: 10000 });
+    });
+  });
+
+  test.describe('affect field editing', () => {
+    test('can edit affectedness via dropdown', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+
+      // Find the Affectedness column by header index
+      const headerCells = affectsTable.locator('thead th');
+      const headerCount = await headerCells.count();
+
+      let affectednessIndex = -1;
+      for (let i = 0; i < headerCount; i++) {
+        const headerText = await headerCells.nth(i).textContent();
+        if (headerText?.toLowerCase().includes('affectedness')) {
+          affectednessIndex = i;
+          break;
+        }
+      }
+
+      if (affectednessIndex >= 0) {
+        const cell = dataRow.locator('td').nth(affectednessIndex);
+        await cell.dblclick();
+
+        // Should show a select dropdown
+        const dropdown = page.locator('select:visible').first();
+        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
+
+        if (isDropdownVisible) {
+          await expect(dropdown).toBeVisible();
+        }
+
+        await page.keyboard.press('Escape');
+      }
+    });
+
+    test('can edit resolution via dropdown', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+
+      const headerCells = affectsTable.locator('thead th');
+      const headerCount = await headerCells.count();
+
+      let resolutionIndex = -1;
+      for (let i = 0; i < headerCount; i++) {
+        const headerText = await headerCells.nth(i).textContent();
+        if (headerText?.toLowerCase().includes('resolution')) {
+          resolutionIndex = i;
+          break;
+        }
+      }
+
+      if (resolutionIndex >= 0) {
+        const cell = dataRow.locator('td').nth(resolutionIndex);
+        await cell.dblclick();
+
+        const dropdown = page.locator('select:visible').first();
+        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
+
+        if (isDropdownVisible) {
+          await expect(dropdown).toBeVisible();
+        }
+
+        await page.keyboard.press('Escape');
+      }
+    });
+
+    test('can edit impact via dropdown', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+      const dataRow = affectsTable.locator('tbody tr').first();
+
+      const headerCells = affectsTable.locator('thead th');
+      const headerCount = await headerCells.count();
+
+      let impactIndex = -1;
+      for (let i = 0; i < headerCount; i++) {
+        const headerText = await headerCells.nth(i).textContent();
+        if (headerText?.toLowerCase().includes('impact')) {
+          impactIndex = i;
+          break;
+        }
+      }
+
+      if (impactIndex >= 0) {
+        const cell = dataRow.locator('td').nth(impactIndex);
+        await cell.dblclick();
+
+        const dropdown = page.locator('select:visible').first();
+        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
+
+        if (isDropdownVisible) {
+          await expect(dropdown).toBeVisible();
+        }
+
+        await page.keyboard.press('Escape');
+      }
+    });
+  });
+
+  test.describe('remove and recover affects', () => {
+    test('can select and remove an affect', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+
+      // Select first affect
+      const dataRow = affectsTable.locator('tbody tr').first();
+      const checkbox = dataRow.locator('input[type="checkbox"]');
+
+      if (!(await checkbox.isChecked())) {
+        await checkbox.click();
+      }
+      await page.waitForTimeout(500);
+
+      // Click remove button (trash icon in toolbar)
+      const removeButton = page.locator('.affects-table-actions button:has(i.bi-trash), button[title*="Remove all selected"]').first();
+      const isRemoveVisible = await removeButton.isVisible({ timeout: 3000 }).catch(() => false);
+
+      if (isRemoveVisible) {
+        await removeButton.click();
+        await page.waitForTimeout(500);
+
+        // Should show "Removed X" badge or row should be marked as removed
+        const removedBadge = page.getByText(/Removed \d+/);
+        const removedRow = affectsTable.locator('tbody tr.removed, tbody tr.text-muted');
+
+        const hasRemovedIndicator
+          = await removedBadge.isVisible({ timeout: 3000 }).catch(() => false)
+            || await removedRow.first().isVisible({ timeout: 1000 }).catch(() => false);
+
+        expect(hasRemovedIndicator).toBeTruthy();
+      }
+    });
+
+    test('can recover a removed affect', async ({ page }) => {
+      // Check if there's a "Removed" badge
+      const removedBadge = page.getByText(/Removed \d+/);
+      const hasBadge = await removedBadge.isVisible({ timeout: 3000 }).catch(() => false);
+
+      if (hasBadge) {
+        // Click recover button
+        const recoverButton = page.locator('button[title*="Recover"], button:has(i.bi-arrow-counterclockwise)').first();
+        const isRecoverVisible = await recoverButton.isVisible({ timeout: 3000 }).catch(() => false);
+
+        if (isRecoverVisible) {
+          await recoverButton.click();
+          await page.waitForTimeout(500);
+
+          // Badge should disappear
+          await expect(removedBadge).not.toBeVisible({ timeout: 5000 });
+        }
+      }
+    });
+  });
+
+  test.describe('module filters', () => {
+    test('module filter section appears when modules exist', async ({ page }) => {
+      // Module filters only appear when there are affected modules
+      // Check if the funnel icon or "Affected Module Filters" text is visible
+      const moduleFilterLabel = page.locator('label, button').filter({ has: page.locator('i.bi-funnel, i.bi-funnel-fill') });
+      const hasModuleFilters = await moduleFilterLabel.first().isVisible({ timeout: 5000 }).catch(() => false);
+
+      if (hasModuleFilters) {
+        await expect(moduleFilterLabel.first()).toBeVisible();
+      } else {
+        // If no module filters, that's OK - might not have valid modules
+        expect(true).toBeTruthy();
+      }
+    });
+  });
+});

--- a/tests/affects.spec.ts
+++ b/tests/affects.spec.ts
@@ -1,63 +1,60 @@
 import { FlawCreatePage } from '../pages/flawCreate';
+import { FlawEditPage, AFFECT_COLUMN_MAP } from '../pages/flawEdit';
 import { test, expect } from '../playwright/fixtures';
 
 test.describe('affects', () => {
-  test.describe.configure({ mode: 'serial' });
-  test.slow(); // Mark all tests as slow (3x timeout)
+  test.slow();
 
-  let flawId: string;
-
-  test.beforeAll(async () => {
-    flawId = await FlawCreatePage.createFlawWithAPI();
-  });
-
-  test.beforeEach(async ({ page }) => {
+  // Helper to navigate to flaw and scroll to affects section
+  const setupFlawPage = async (page: import('@playwright/test').Page, flawId: string) => {
     await page.goto(`/flaws/${flawId}`);
-    // Wait for page to load with longer timeout
     await page.waitForLoadState('networkidle', { timeout: 90000 });
     await expect(page.getByRole('button', { name: 'Save Changes', exact: true })).toBeVisible({ timeout: 90000 });
-    // Scroll to Affected Offerings section
     const heading = page.getByRole('heading', { name: 'Affected Offerings' });
     await heading.scrollIntoViewIfNeeded();
-  });
+  };
+
+  // Helper to create a flaw with one affect already saved
+  const createFlawWithAffect = async (browser: import('@playwright/test').Browser): Promise<string> => {
+    const flawId = await FlawCreatePage.createFlawWithAPI();
+    const page = await browser.newPage();
+    await setupFlawPage(page, flawId);
+    const flawEditPage = new FlawEditPage(page);
+    await flawEditPage.addAffect({ productStream: 'rhel-8.10.0', module: 'rhel-8', component: 'kernel' });
+    await flawEditPage.submitButton.click();
+    await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
+    await page.close();
+    return flawId;
+  };
 
   test.describe('add affects', () => {
-    test('add affect button is visible', async ({ page }) => {
-      const addButton = page.locator('button[title="Add new affect"]');
-      await expect(addButton).toBeVisible();
+    let flawId: string;
+
+    test.beforeAll(async () => {
+      flawId = await FlawCreatePage.createFlawWithAPI();
     });
 
-    test('can add first affect', async ({ page, flawEditPage }) => {
-      await flawEditPage.addAffect('rhel-8', 'kernel');
-      await flawEditPage.submitButton.click();
-      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
+    test.beforeEach(async ({ page }) => {
+      await setupFlawPage(page, flawId);
     });
 
-    test('can add second affect', async ({ page, flawEditPage }) => {
-      await flawEditPage.addAffect('rhel-9', 'glibc');
-      await flawEditPage.submitButton.click();
-      await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
-    });
-
-    test('new affect row shows product stream before save', async ({ page, flawEditPage }) => {
-      await flawEditPage.addAffect('fedora-40', 'openssl');
-      // New row should show the product stream we entered (before saving)
-      const newRow = page.locator('tr.new').last();
-      await expect(newRow).toContainText('fedora-40');
-      // Save it
+    test('can add affect', async ({ page, flawEditPage }) => {
+      await flawEditPage.addAffect({ productStream: 'rhel-8.10.0', module: 'rhel-8', component: 'kernel' });
       await flawEditPage.submitButton.click();
       await expect(page.getByText(/\d+ affects? created/i)).toBeVisible({ timeout: 60000 });
     });
   });
 
   test.describe('table features', () => {
-    test('table shows affects', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const rows = affectsTable.locator('tbody tr');
-      const count = await rows.count();
-      expect(count).toBeGreaterThan(0);
+    let flawId: string;
+
+    test.beforeAll(async ({ browser }) => {
+      flawId = await createFlawWithAffect(browser);
     });
 
+    test.beforeEach(async ({ page }) => {
+      await setupFlawPage(page, flawId);
+    });
     test('table has Product Stream header', async ({ page }) => {
       const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
       await expect(affectsTable.getByText('Product Stream')).toBeVisible({ timeout: 15000 });
@@ -68,75 +65,60 @@ test.describe('affects', () => {
       await expect(affectsTable.getByText('Component', { exact: true })).toBeVisible({ timeout: 15000 });
     });
 
-    test('shows affect count', async ({ page }) => {
+    test('shows affect count badge', async ({ page }) => {
       const showAllLabel = page.getByText(/Show All \(\d+\)/);
       await expect(showAllLabel).toBeVisible({ timeout: 15000 });
     });
   });
 
   test.describe('edit affects', () => {
-    test('can double-click cell to enter edit mode', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const dataRow = affectsTable.locator('tbody tr').first();
-      const cell = dataRow.locator('td').nth(3);
-      await cell.dblclick();
+    let flawId: string;
 
-      const textInput = page.locator('input[type="text"]:visible').first();
-      await expect(textInput).toBeVisible({ timeout: 10000 });
-
-      await textInput.press('Escape');
+    test.beforeAll(async ({ browser }) => {
+      flawId = await createFlawWithAffect(browser);
     });
 
-    test('escape cancels edit without saving', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const dataRow = affectsTable.locator('tbody tr').first();
-      const cell = dataRow.locator('td').nth(3);
-
-      await cell.dblclick();
-
-      const textInput = page.locator('input[type="text"]:visible').first();
-      await textInput.waitFor({ state: 'visible', timeout: 10000 });
-      await textInput.fill('should-be-cancelled');
-      await textInput.press('Escape');
-
-      // Wait a moment for the edit to cancel
-      await page.waitForTimeout(1000);
-
-      // Click on the Affected Offerings heading to exit edit mode
-      const heading = page.getByRole('heading', { name: 'Affected Offerings' });
-      await heading.click();
-      await page.waitForTimeout(500);
+    test.beforeEach(async ({ page }) => {
+      await setupFlawPage(page, flawId);
     });
 
     test('can edit and save affect', async ({ page, flawEditPage }) => {
       const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
       const dataRow = affectsTable.locator('tbody tr').first();
-      const cell = dataRow.locator('td').nth(5);
+      // TODO: nth() indices break if columns are hidden/reordered via user settings (persisted in browser).
+      // Fix requires OSIM to expose data-column-id attributes on cells.
+      const cell = dataRow.locator('td').nth(AFFECT_COLUMN_MAP.Component);
       await cell.dblclick();
 
-      const textInput = page.locator('input[type="text"]:visible').first();
+      const textInput = cell.locator('input[type="text"]');
       await textInput.waitFor({ state: 'visible', timeout: 10000 });
       await textInput.fill(`edited-${Date.now()}`);
-      await textInput.press('Escape');
+      await textInput.press('Enter');
 
-      await page.waitForTimeout(500);
+      await expect(dataRow).toHaveClass(/modified/, { timeout: 5000 });
       await flawEditPage.submitButton.click();
 
-      // Wait for save to complete
       await expect(page.getByText(/Flaw saved|\d+ affects? updated/i)).toBeVisible({ timeout: 60000 });
     });
   });
 
   test.describe('select affects', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    let flawId: string;
+
+    test.beforeAll(async ({ browser }) => {
+      flawId = await createFlawWithAffect(browser);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await setupFlawPage(page, flawId);
+    });
+
     test('can toggle checkbox selection', async ({ page }) => {
       const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
       const dataRow = affectsTable.locator('tbody tr').first();
       const checkbox = dataRow.locator('input[type="checkbox"]');
-
-      // Ensure unchecked
-      if (await checkbox.isChecked()) {
-        await checkbox.click();
-      }
 
       await checkbox.click();
       await expect(checkbox).toBeChecked();
@@ -148,188 +130,51 @@ test.describe('affects', () => {
     test('header checkbox selects all', async ({ page }) => {
       const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
       const headerCheckbox = affectsTable.locator('thead input[type="checkbox"]');
-      if (await headerCheckbox.isVisible()) {
-        await headerCheckbox.click();
-        const bodyCheckbox = affectsTable.locator('tbody tr').first().locator('input[type="checkbox"]');
-        await expect(bodyCheckbox).toBeChecked({ timeout: 5000 });
-        // Cleanup
-        await headerCheckbox.click();
-      }
-    });
-  });
+      const bodyCheckbox = affectsTable.locator('tbody tr').first().locator('input[type="checkbox"]');
 
-  test.describe('display modes', () => {
-    test('show all badge is visible', async ({ page }) => {
-      // The badge shows "Show All (X)" where X is the count
-      const showAllBadge = page.getByText(/Show All \(\d+\)/);
-      await expect(showAllBadge).toBeVisible({ timeout: 10000 });
-    });
-  });
+      await expect(headerCheckbox).toBeVisible({ timeout: 10000 });
 
-  test.describe('affect field editing', () => {
-    test('can edit affectedness via dropdown', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const dataRow = affectsTable.locator('tbody tr').first();
+      await headerCheckbox.click();
+      await expect(bodyCheckbox).toBeChecked({ timeout: 5000 });
 
-      // Find the Affectedness column by header index
-      const headerCells = affectsTable.locator('thead th');
-      const headerCount = await headerCells.count();
-
-      let affectednessIndex = -1;
-      for (let i = 0; i < headerCount; i++) {
-        const headerText = await headerCells.nth(i).textContent();
-        if (headerText?.toLowerCase().includes('affectedness')) {
-          affectednessIndex = i;
-          break;
-        }
-      }
-
-      if (affectednessIndex >= 0) {
-        const cell = dataRow.locator('td').nth(affectednessIndex);
-        await cell.dblclick();
-
-        // Should show a select dropdown
-        const dropdown = page.locator('select:visible').first();
-        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
-
-        if (isDropdownVisible) {
-          await expect(dropdown).toBeVisible();
-        }
-
-        await page.keyboard.press('Escape');
-      }
-    });
-
-    test('can edit resolution via dropdown', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const dataRow = affectsTable.locator('tbody tr').first();
-
-      const headerCells = affectsTable.locator('thead th');
-      const headerCount = await headerCells.count();
-
-      let resolutionIndex = -1;
-      for (let i = 0; i < headerCount; i++) {
-        const headerText = await headerCells.nth(i).textContent();
-        if (headerText?.toLowerCase().includes('resolution')) {
-          resolutionIndex = i;
-          break;
-        }
-      }
-
-      if (resolutionIndex >= 0) {
-        const cell = dataRow.locator('td').nth(resolutionIndex);
-        await cell.dblclick();
-
-        const dropdown = page.locator('select:visible').first();
-        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
-
-        if (isDropdownVisible) {
-          await expect(dropdown).toBeVisible();
-        }
-
-        await page.keyboard.press('Escape');
-      }
-    });
-
-    test('can edit impact via dropdown', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
-      const dataRow = affectsTable.locator('tbody tr').first();
-
-      const headerCells = affectsTable.locator('thead th');
-      const headerCount = await headerCells.count();
-
-      let impactIndex = -1;
-      for (let i = 0; i < headerCount; i++) {
-        const headerText = await headerCells.nth(i).textContent();
-        if (headerText?.toLowerCase().includes('impact')) {
-          impactIndex = i;
-          break;
-        }
-      }
-
-      if (impactIndex >= 0) {
-        const cell = dataRow.locator('td').nth(impactIndex);
-        await cell.dblclick();
-
-        const dropdown = page.locator('select:visible').first();
-        const isDropdownVisible = await dropdown.isVisible({ timeout: 5000 }).catch(() => false);
-
-        if (isDropdownVisible) {
-          await expect(dropdown).toBeVisible();
-        }
-
-        await page.keyboard.press('Escape');
-      }
+      await headerCheckbox.click();
+      await expect(bodyCheckbox).not.toBeChecked({ timeout: 5000 });
     });
   });
 
   test.describe('remove and recover affects', () => {
-    test('can select and remove an affect', async ({ page }) => {
-      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
+    let flawId: string;
 
-      // Select first affect
+    test.beforeAll(async ({ browser }) => {
+      flawId = await createFlawWithAffect(browser);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await setupFlawPage(page, flawId);
+    });
+
+    test('can remove and recover an affect', async ({ page }) => {
+      const affectsTable = page.locator('table').filter({ has: page.locator('thead:has-text("Product Stream")') }).first();
       const dataRow = affectsTable.locator('tbody tr').first();
       const checkbox = dataRow.locator('input[type="checkbox"]');
 
-      if (!(await checkbox.isChecked())) {
-        await checkbox.click();
-      }
-      await page.waitForTimeout(500);
+      await checkbox.click();
 
-      // Click remove button (trash icon in toolbar)
-      const removeButton = page.locator('.affects-table-actions button:has(i.bi-trash), button[title*="Remove all selected"]').first();
-      const isRemoveVisible = await removeButton.isVisible({ timeout: 3000 }).catch(() => false);
+      // Remove via toolbar
+      const removeButton = page.locator('button[title="Remove selected affects"]');
+      await expect(removeButton).toBeVisible({ timeout: 5000 });
+      await removeButton.click();
 
-      if (isRemoveVisible) {
-        await removeButton.click();
-        await page.waitForTimeout(500);
+      // Row gets 'removed' class
+      await expect(dataRow).toHaveClass(/removed/, { timeout: 5000 });
 
-        // Should show "Removed X" badge or row should be marked as removed
-        const removedBadge = page.getByText(/Removed \d+/);
-        const removedRow = affectsTable.locator('tbody tr.removed, tbody tr.text-muted');
+      // Revert via per-row action
+      const revertButton = dataRow.locator('button[title="Revert changes"]');
+      await expect(revertButton).toBeVisible({ timeout: 5000 });
+      await revertButton.click();
 
-        const hasRemovedIndicator
-          = await removedBadge.isVisible({ timeout: 3000 }).catch(() => false)
-            || await removedRow.first().isVisible({ timeout: 1000 }).catch(() => false);
-
-        expect(hasRemovedIndicator).toBeTruthy();
-      }
-    });
-
-    test('can recover a removed affect', async ({ page }) => {
-      // Check if there's a "Removed" badge
-      const removedBadge = page.getByText(/Removed \d+/);
-      const hasBadge = await removedBadge.isVisible({ timeout: 3000 }).catch(() => false);
-
-      if (hasBadge) {
-        // Click recover button
-        const recoverButton = page.locator('button[title*="Recover"], button:has(i.bi-arrow-counterclockwise)').first();
-        const isRecoverVisible = await recoverButton.isVisible({ timeout: 3000 }).catch(() => false);
-
-        if (isRecoverVisible) {
-          await recoverButton.click();
-          await page.waitForTimeout(500);
-
-          // Badge should disappear
-          await expect(removedBadge).not.toBeVisible({ timeout: 5000 });
-        }
-      }
-    });
-  });
-
-  test.describe('module filters', () => {
-    test('module filter section appears when modules exist', async ({ page }) => {
-      // Module filters only appear when there are affected modules
-      // Check if the funnel icon or "Affected Module Filters" text is visible
-      const moduleFilterLabel = page.locator('label, button').filter({ has: page.locator('i.bi-funnel, i.bi-funnel-fill') });
-      const hasModuleFilters = await moduleFilterLabel.first().isVisible({ timeout: 5000 }).catch(() => false);
-
-      if (hasModuleFilters) {
-        await expect(moduleFilterLabel.first()).toBeVisible();
-      } else {
-        // If no module filters, that's OK - might not have valid modules
-        expect(true).toBeTruthy();
-      }
+      // Verify 'removed' class is gone
+      await expect(dataRow).not.toHaveClass(/removed/, { timeout: 5000 });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds UI test suite for the Affects section and refactors the `flawEdit.ts` page object to match the current OSIM inline-editing table UI.

- Add 9 tests covering the Affected Offerings section
- Fix `flawEdit.ts` locators to match current OSIM DOM (`#affected-offerings`, `tr.new`, real button titles)
- Implement `addAffect()` using `dblclick()` + `Enter` cell-editing workflow

## Test Coverage

| Category | Tests | Description |
|---|---|---|
| Add affects | 1 | Create and persist an affect |
| Table features | 3 | Headers (Product Stream, Component), affect count badge |
| Edit affects | 1 | Inline cell edit and save |
| Select affects | 2 | Row checkbox toggle, header select-all |
| Remove/Recover | 1 | Toolbar remove, per-row revert |
